### PR TITLE
Integrate calib prep

### DIFF
--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -507,9 +507,14 @@ class mkrefsclass(astrotableclass):
         print("pipeline-run files. What if darks and flats are in totally seaparate")
         print("areas? Would be inefficient to back way out and search all subdirs.")
         print("Maybe search_dir can be a list of directories??")
-        mmm.search_dir = "/ifs/jwst/wit/nircam/isim_cv3_files_for_calibrations/darks/"
-        # Need to get these directories programmatically
-        mmm.output_dir = "/Users/hilbert/python_repos/test_jwst_reffiles/"
+        # mmm.search_dir = "/ifs/jwst/wit/nircam/isim_cv3_files_for_calibrations/darks/"
+        mmm.search_dir = self.cfg.params["pipeline_prod_search_dir"]
+
+        if self.cfg.params['output']['outsubdir'] is not None:
+            mmm.output_dir = os.path.join(self.cfg.params['output']['outrootdir'],
+                                          self.cfg.params['output']['outsubdir'])
+        else:
+            mmm.output_dir = self.cfg.params['output']['outrootdir']
         mmm.prepare()
 
 

--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -15,8 +15,10 @@ import astropy
 import numpy as np
 import scipy
 
-from .utils.tools import astrotableclass,yamlcfgclass
-from .mkref import mkrefclass
+from jwst_reffiles.mkref import mkrefclass
+from jwst_reffiles.pipeline.calib_prep import CalibPrep
+from jwst_reffiles.utils.tools import astrotableclass,yamlcfgclass
+
 
 # get the root dir of the code. This is needed only if the scripts are not installed as a module!
 #if 'JWST_MKREFS_SRCDIR' in os.environ:
@@ -491,6 +493,11 @@ class mkrefsclass(astrotableclass):
         print(self.cmdtable.t)
         print('\n### INPUT FILES:')
         print(self.inputimagestable.t)
+
+        mmm = CalibPrep()
+        mmm.inputs = self.inputimagestable.t
+        mmm.prepare()
+
 
         print('BRYAN: here we call your script to get the outoput filenames and the commands to run SSB!')
         print('input is the self.inputimagestable')

--- a/jwst_reffiles/utils/definitions.py
+++ b/jwst_reffiles/utils/definitions.py
@@ -1,0 +1,19 @@
+#! /usr/bin/env python
+
+"""File containing various necessary definitions, such as abbreviations for each
+pipeline step
+"""
+
+# Abbreviations for pipeline steps. The abbreviations (keys) here, must be used
+# in the configuration files when listing pipeline steps
+PIPE_STEPS = [('dq', 'dq_init'), ('sat', 'saturation'), ('super', 'superbias'),
+              ('ref', 'refpix'), ('ipc', 'ipc'), ('lin', 'linearity'),
+              ('persistence', 'persistence'), ('dark', 'dark_current'),
+              ('jump', 'jump'), ('rampfit', 'rate'), ('wcs', 'assign_wcs')]
+
+# Define header keyword that accompanies each step
+# This needs to be made more instrument-agnostic. The list is going to
+# vary depending on the instrument.
+PIPE_KEYWORDS = {'S_DQINIT': 'dq', 'S_SATURA': 'sat', 'S_REFPIX': 'ref', 'S_SUPERB': 'super',
+                 'S_IPC': 'ipc', 'S_PERSIS': 'persistence', 'S_DARK': 'dark', 'S_LINEAR': 'lin',
+                 'S_JUMP': 'jump',  'S_RAMP': 'rampfit', 'S_WCS': 'wcs'}


### PR DESCRIPTION
This PR introduces changes to `mkrefs.py` and `calib_prep.py` in order to allow them to work together. These changes appear to work successfully for my test case. `calib_prep.py` returns a list of command line calls to the JWST calibration pipeline which can be farmed out to condor. 

I also created `utils/definitions.py` to hold commonly used definitions. Currently it contains a dictionary of abbreviations to be used for pipeline steps, as well as a dictionary of header keywords associated with each pipeline step.

Further work will be necessary, since different pipeline steps are used for each instrument. Currently the definitions are NIRCam-centric, although they probably should work for the other near-IR instruments fairly well. Updates will have to be made for MIRI.

I'm pushing these changes now because they are functional, and development of the next steps (like generating the calls to condor, which will be done by @arminrest) can take place once this code is merged. We can use a separate PR at some point later to clean up the code and make it functional for other instruments.

@arminrest do you feel comfortable reviewing this PR?