### PR TITLE
Remove reference to mirage and add jwst_reffiles in api.rst

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,12 +1,12 @@
 
-API Documentation 
+API Documentation
 ==================
 
-.. automodule:: mirage.imaging_simulator
+.. automodule:: jwst_reffiles.mkrefs
 
-.. automodule:: mirage.wfss_simulator
+.. automodule:: jwst_reffiles.mkref
 
-.. automodule:: mirage
+.. automodule:: jwst_reffiles
         :members:
         :undoc-members:
 


### PR DESCRIPTION
Removed leftover `mirage` references in api.rst from when this file was copied over into the repo.