### PR TITLE
Pipeline multiple repeats

### DIFF
--- a/jwst_reffiles/mkrefs.cfg
+++ b/jwst_reffiles/mkrefs.cfg
@@ -19,9 +19,9 @@ inputfiles:
    # TIME-OBS if specified) are used to determine the MJD.
    dateobs_fitskey: DATE-END
    timeobs_fitskey: TIME-END
-   mjdobs_fitskey:  
+   mjdobs_fitskey:
 
-   requiredfitskeys: [INSTRUME,DETECTOR,NGROUP,NINT,TGROUP,SUBARRAY]
+   requiredfitskeys: [INSTRUME,DETECTOR,NGROUPS,NINTS,TGROUP,SUBARRAY]
    optionalfitskeys: [FILTER,PUPIL]
 
 DD:
@@ -49,12 +49,12 @@ output:
    skip_runID_ssbdir: False
 
    # directories in which ssb products are looked for. comma-separated list!
-   pipeline_prod_search_dir: 
+   pipeline_prod_search_dir:
 
 batch:
    batch_enabled: False
    batchmode: Condor
-   
+
 
 test1: 4
 
@@ -67,7 +67,7 @@ reffile4ssb:
 validation:
    gainreffile: CRDS
    bpmreffile: CRDS
-   
+
 bpm:
     reftype: bpm
     imtypes: D

--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -18,8 +18,8 @@ import scipy
 
 from jwst_reffiles.mkref import mkrefclass
 from jwst_reffiles.pipeline.calib_prep import CalibPrep
-from jwst_reffiles.utils.tools import astrotableclass,yamlcfgclass
-
+from jwst_reffiles.utils.tools import astrotableclass, yamlcfgclass
+from jwst_reffiles.utils.tools import makepath
 
 # get the root dir of the code. This is needed only if the scripts are not installed as a module!
 #if 'JWST_MKREFS_SRCDIR' in os.environ:
@@ -31,7 +31,6 @@ from jwst_reffiles.utils.tools import astrotableclass,yamlcfgclass
 rootdir = os.path.dirname(os.path.realpath(__file__))
 
 
-
 class cmdsclass(astrotableclass):
     def __init__(self):
         astrotableclass.__init__(self)
@@ -41,19 +40,19 @@ class mkrefsclass(astrotableclass):
     def __init__(self):
         astrotableclass.__init__(self)
 
-        #config file
+        # config file
         self.cfg = None
 
         self.verbose = 0
         self.debug = False
         self.onlyshow = False
 
-        self.basedir=None
-        self.basename=None
-        self.outsubdir=None
-        self.ssbdir=None
-        self.runID=None
-        self.runlabel=None
+        self.basedir = None
+        self.basename = None
+        self.outsubdir = None
+        self.ssbdir = None
+        self.runID = None
+        self.runlabel = None
 
         self.imtable = astrotableclass()
         self.images4ssb = astrotableclass()
@@ -67,28 +66,31 @@ class mkrefsclass(astrotableclass):
 
         self.cmdtable = cmdsclass()
 
-        self.allowed_reflabels = ['bpm','rdnoise_nircam','gain_armin']
-
+        self.allowed_reflabels = ['bpm', 'rdnoise_nircam', 'gain_armin']
 
     def define_options(self, parser=None, usage=None, conflict_handler='resolve'):
         if parser is None:
             parser = argparse.ArgumentParser(usage=usage, conflict_handler=conflict_handler)
         parser.add_argument("reflabels_and_imagelist", nargs='+', help=("list of ref types to be done"
-                                                                       "and image (or file patterns) lists"))
+                                                                        "and image (or file patterns) lists"))
         parser.add_argument('-b', '--batchmode', help="run the commands in batch mode (default=%(default)s)",
                             action="store_true", default=False)
         parser.add_argument('--onlyshow', help="only show what would be done, but don't do it."
                                                "(default=%(default)s)", action="store_true", default=False)
 
         parser.add_argument('--outrootdir', default=None,
-                            help=('output root directory. outrootdir[/outsubdir][/runID]/reflabel/reflabel[_outsubdir][_runID][.addsuffix].cmdID.reftype.fits (default=%(default)s)'))
+                            help=('output root directory. outrootdir[/outsubdir][/runID]/reflabel/'
+                                  'reflabel[_outsubdir][_runID][.addsuffix].cmdID.reftype.fits '
+                                  '(default=%(default)s)'))
         parser.add_argument('--outsubdir', default=None,
-                            help='subdir added to the output root directory (and filename) (default=%(default)s)')
+                            help=('subdir added to the output root directory (and filename) '
+                                  '(default=%(default)s)'))
         parser.add_argument('--addsuffix', default=None,
                             help='suffix added to the output basename (default=%(default)s)')
 
         parser.add_argument('--runID', default=None,
-                            help='runID subdir added to output root directory (and filename) (default=%(default)s)')
+                            help=('runID subdir added to output root directory (and filename) '
+                                  '(default=%(default)s)'))
         parser.add_argument('--runIDNdigits', default=None,
                             help='how many leading zeros in runID (default=%(default)s)')
         parser.add_argument('-n', '--newrunID', help="get the next available runID",
@@ -107,7 +109,8 @@ class mkrefsclass(astrotableclass):
             mkrefpackage = __import__("mkref_%s" % reflabel)
             mkref = mkrefpackage.mkrefclassX()
             # Only load defaultoptions once...
-            if reflabel==self.allowed_reflabels[0]: mkref.defaultoptions(parser)
+            if reflabel == self.allowed_reflabels[0]:
+                mkref.defaultoptions(parser)
             # get the reflabel specific options
             mkref.extraoptions(parser)
         return(parser)
@@ -122,7 +125,7 @@ class mkrefsclass(astrotableclass):
             raise RuntimeError("Something went wrong when loading config files!")
         return(0)
 
-    def getbasedir(self, outrootdir=None, outsubdir=None, runlabel = None):
+    def getbasedir(self, outrootdir=None, outsubdir=None, runlabel=None):
         """ basedir based on options and cfg file: outrootdir[/outsubdir][/runID]"""
         if outrootdir is None:
             if self.cfg.params['output']['outrootdir'] == '':
@@ -130,7 +133,7 @@ class mkrefsclass(astrotableclass):
             else:
                 outrootdir = self.cfg.params['output']['outrootdir']
 
-        basedir = outrootdir
+        basedir = os.path.abspath(os.path.expandvars(outrootdir))
         basename = ''
 
         # outsubdir: test if outsubdir is passed or if it is specified in the config file ...
@@ -139,41 +142,44 @@ class mkrefsclass(astrotableclass):
         # ... and if yes, add it
         if outsubdir is not None:
             basedir += '/%s' % outsubdir
-            if basename != '': basename += '_'
+            if basename != '':
+                basename += '_'
             basename += outsubdir
 
-        if runlabel != None:
+        if runlabel is not None:
             basedir += '/%s' % runlabel
-            if basename != '': basename += '_'
+            if basename != '':
+                basename += '_'
             basename += runlabel
 
-        if basename == '': basename = 'B'
+        if basename == '':
+            basename = 'B'
 
-        return(basedir,'%s/%s' % (basedir,basename),outsubdir)
+        return(basedir, '%s/%s' % (basedir, basename), outsubdir)
 
     def getbasename(self):
         s = self.basedir+'/'
-        if self.outsubdir!=None:
+        if self.outsubdir is not None:
             s += '%s/' % self.outsubdir
-        if self.runID!=None:
+        if self.runID is not None:
             s += '%s/' % self.outsubdir
 
-    def getssbdir(self, ssbdir, basedir, skip_runID_ssbdir = False):
+    def getssbdir(self, ssbdir, basedir, skip_runID_ssbdir=False):
         """ get the ssbdir. It can be hardcoded to a directory with
         --ssbdir or in the cfg file. If it is not specified, then
         basedir/ssb is used"""
-        if ssbdir != None and ssbdir != '':
+        if ssbdir is not None and ssbdir != '':
             return(ssbdir)
-        elif self.cfg.params['output']['ssbdir']!=None and self.cfg.params['output']['ssbdir']!='':
-             return(self.cfg.params['output']['ssbdir'])
+        elif self.cfg.params['output']['ssbdir'] is not None and self.cfg.params['output']['ssbdir'] != '':
+            return(self.cfg.params['output']['ssbdir'])
         else:
             return('%s/ssb' % self.basedir)
         return(None)
 
-    def get_highest_runID(self,basedir):
+    def get_highest_runID(self, basedir):
         """ find all subdirs witn run\d+ within the passed basedir, and extract the highest runID"""
         files = glob.glob('%s/run*' % basedir)
-        if len(files)==0:
+        if len(files) == 0:
             print('No runIDs yet!')
             return(None)
         runIDs = []
@@ -181,53 +187,54 @@ class mkrefsclass(astrotableclass):
         for fname in files:
             print(os.path.basename(fname))
             m = runIDpattern.search(fname)
-            if m!=None:
+            if m is not None:
                 runID = int(m.groups()[0])
                 runIDs.append(runID)
-        if len(runIDs)>0:
+        if len(runIDs) > 0:
             runID = max(runIDs)
         else:
-            runID=None
+            runID = None
         return(runID)
 
-    def set_runID(self,outrootdir = None, outsubdir = None, runID = None, runIDNdigits = None, newrunID = False):
+    def set_runID(self, outrootdir=None, outsubdir=None, runID=None, runIDNdigits=None, newrunID=False):
         """ set the runID depending on the options and config file """
 
         # if no runID is specified with the options, then use the one from the cfg file
-        if runID==None:
+        if runID is None:
             runID = mkrefs.cfg.params['output']['runID']
 
-        if runID == '' or runID==None:
+        if runID == '' or runID is None:
             # If no runID specified, make sure it is set to None!
             self.runID = None
-        elif isinstance(runID,int) or runID.isdigit():
+        elif isinstance(runID, int) or runID.isdigit():
             # if runID is an integer, set it to it!
             self.runID = int(runID)
         else:
             # if runID is AUTO, get the current highest runID, and increment if --new_runID (-n)
-            if runID.upper()=='AUTO':
-                (basedir,basename,subdir) = self.getbasedir(outrootdir=outrootdir, outsubdir=outsubdir, runlabel=None)
+            if runID.upper() == 'AUTO':
+                (basedir, basename, subdir) = self.getbasedir(outrootdir=outrootdir, outsubdir=outsubdir,
+                                                              runlabel=None)
                 self.runID = self.get_highest_runID(basedir)
-                if self.runID == None:
+                if self.runID is None:
                     self.runID = 0
                 else:
                     if newrunID:
-                        self.runID+=1
+                        self.runID += 1
             else:
                 raise RuntimeError("Incorrect runID=%s requested!" % runID)
 
-        if self.runID!=None:
-            if runIDNdigits==None:
+        if self.runID is not None:
+            if runIDNdigits is None:
                 runIDNdigits = self.cfg.params['output']['runIDNdigits']
-            if runIDNdigits==None:
-                runIDNdigits=1
+            if runIDNdigits is None:
+                runIDNdigits = 1
 
             b = 'run%0'+'%d' % runIDNdigits+'d'
             self.runlabel = b % (self.runID)
         else:
             self.runlabel = ''
 
-        return(self.runID,self.runlabel)
+        return(self.runID, self.runlabel)
 
     #def getssbdir(self, ssbdir=None, **kwarg):
     #    if ssbdir != None and ssbdir != '':
@@ -235,23 +242,31 @@ class mkrefsclass(astrotableclass):
     #    ssbdir = '%s/ssb' % self.getbasedir(**kwarg)
     #    return(ssbdir)
 
-    def set_dirs(self,outrootdir = None, outsubdir = None, runID = None, runIDNdigits = 1, newrunID = False, ssbdir=None, skip_runID_ssbdir=False):
+    def set_dirs(self, outrootdir=None, outsubdir=None, runID=None, runIDNdigits=1, newrunID=False,
+                 ssbdir=None, skip_runID_ssbdir=False):
         # get the runID
-        mkrefs.set_runID(outrootdir = outrootdir, outsubdir = outsubdir,
-                         runID = runID, runIDNdigits =runIDNdigits, newrunID = newrunID)
+        mkrefs.set_runID(outrootdir=outrootdir, outsubdir=outsubdir,
+                         runID=runID, runIDNdigits=runIDNdigits, newrunID=newrunID)
 
-        (self.basedir,self.basename,self.outsubdir) = self.getbasedir(outrootdir=outrootdir, outsubdir=outsubdir, runlabel=self.runlabel)
+        (self.basedir, self.basename, self.outsubdir) = self.getbasedir(outrootdir=outrootdir,
+                                                                        outsubdir=outsubdir,
+                                                                        runlabel=self.runlabel)
 
-        self.ssbdir = self.getssbdir(ssbdir,self.basedir, skip_runID_ssbdir = skip_runID_ssbdir)
+        self.ssbdir = self.getssbdir(ssbdir, self.basedir, skip_runID_ssbdir=skip_runID_ssbdir)
 
-        if self.verbose>=3:
+        # Create the directories if they don't already exist
+        if not self.onlyshow:
+            state_basedir = makepath(self.basedir)
+            state_ssbdir = makepath(self.ssbdir)
+
+        if self.verbose >= 3:
             print('#### Directories:')
-            print('basedir:',self.basedir)
-            print('basename:',self.basename)
-            print('ssbdir:',self.ssbdir)
-            print('outsubdir:',self.outsubdir)
-            print('runID:',self.runID)
-            print('runlabel:',self.runlabel)
+            print('basedir:', self.basedir)
+            print('basename:', self.basename)
+            print('ssbdir:', self.ssbdir)
+            print('outsubdir:', self.outsubdir)
+            print('runID:', self.runID)
+            print('runlabel:', self.runlabel)
 
         return(0)
 
@@ -282,8 +297,8 @@ class mkrefsclass(astrotableclass):
         if outsubdir is not None:
             outbasename += '/%s' % outsubdir
 
-        outbasename +='/'
-        if reftype!=None:
+        outbasename += '/'
+        if reftype is not None:
             outbasename += '%s_' % (reftype)
         outbasename += re.sub('\.fits$', '', imbasename)
 
@@ -307,7 +322,8 @@ class mkrefsclass(astrotableclass):
         '''
         only keep fits file that match basenamepattern
         '''
-        if self.verbose>1: print("#### Trimming images...")
+        if self.verbose > 1:
+            print("#### Trimming images...")
         # print imagelist
         if imagelist is None or len(imagelist) == 0:
             print('Nothing to do, no images!!!')
@@ -367,7 +383,8 @@ class mkrefsclass(astrotableclass):
 
     def getimageinfo(self, imagelist, dateobsfitskey=None, timeobsfitskey=None, mjdobsfitskey=None):
 
-        if self.verbose>1: print("Getting image info")
+        if self.verbose > 1:
+            print("Getting image info")
 
         # self.imtable['fitsfile'].format('%s')
         self.imtable.t['fitsfile'] = imagelist
@@ -375,7 +392,8 @@ class mkrefsclass(astrotableclass):
         self.imtable.t['imtype'] = None
         self.imtable.t['skip'] = False
 
-        if self.verbose>1: print("Table created")
+        if self.verbose > 1:
+            print("Table created")
 
         requiredfitskeys = self.cfg.params['inputfiles']['requiredfitskeys']
         if requiredfitskeys is None:
@@ -409,7 +427,7 @@ class mkrefsclass(astrotableclass):
     def organize_inputfiles(self, reflabels_and_imagelist):
         # parse teh command line arguments for reflabels and images
         (reflabellist, imagelist) = self.parse_reflabels_images(reflabels_and_imagelist,
-                                                              basenamepattern=self.cfg.params['inputfiles']['basenamepattern'])
+                                                                basenamepattern=self.cfg.params['inputfiles']['basenamepattern'])
         self.reflabellist = reflabellist
 
         # make the image table and populate it with info. Also get teh darks and flats table
@@ -422,25 +440,27 @@ class mkrefsclass(astrotableclass):
 
         if self.verbose:
             print('#################\n### %d images found!' % len(self.imtable.t))
-            print('### %d darks, %d flats' % (len(np.where(self.imtable.t['imtype'] == 'dark')[0]), len(np.where(self.imtable.t['imtype'] == 'flat')[0])))
+            print('### %d darks, %d flats' % (len(np.where(self.imtable.t['imtype'] == 'dark')[0]),
+                                              len(np.where(self.imtable.t['imtype'] == 'flat')[0])))
             print('### %d detectors:' % (len(self.detectors)), ", ".join(self.detectors))
-            if self.verbose>1:
+            if self.verbose > 1:
                 print(self.imtable.t)
 
     def check_inputfiles(self):
-        print('basedir:',self.basedir)
-        print('basename:',self.basename)
+        print('basedir:', self.basedir)
+        print('basename:', self.basename)
 
         # test if output dir already exists.
-        if not os.path.isdir(self.basedir):
-            # if it doesn't exist: write the image list into it if !onlyshow!
-            if not self.onlyshow:
-                if self.verbose>1: print('Creating directory %s' % self.basedir)
-                os.makedirs(self.basedir)
-                if not os.path.isdir(self.basedir):
-                    raise RuntimeError('Cannot create directory %s' % self.basedir)
-            else:
-                print('*** only showing: directory %s would be created here!' % self.basedir)
+        #if not os.path.isdir(self.basedir):
+        #    # if it doesn't exist: write the image list into it if !onlyshow!
+        #    if not self.onlyshow:
+        #        if self.verbose > 1:
+        #            print('Creating directory %s' % self.basedir)
+        #        os.makedirs(self.basedir)
+        #        if not os.path.isdir(self.basedir):
+        #            raise RuntimeError('Cannot create directory %s' % self.basedir)
+        #    else:
+        #        print('*** only showing: directory %s would be created here!' % self.basedir)
 
         imtbl_filename = '%s.im.txt' % self.basename
 
@@ -452,16 +472,22 @@ class mkrefsclass(astrotableclass):
             imtable_before.load(imtbl_filename)
 
             if (len(self.imtable.t['fitsfile']) != len(imtable_before.t['fitsfile'])):
-                raise RuntimeError('length %d of new list of input images is different than the one from the saved table (%d), cannot proceed! either get a new runID with -n, or remove the files in %s' % (len(self.imtable.t['fitsfile']),len(imtable_before.t['fitsfile']),self.basedir))
+                raise RuntimeError(('length %d of new list of input images is different than the one from '
+                                    'the saved table (%d), cannot proceed! either get a new runID with -n, '
+                                    'or remove the files in %s' % (len(self.imtable.t['fitsfile']),
+                                                                   len(imtable_before.t['fitsfile']),
+                                                                   self.basedir)))
 
             for i in range(len(self.imtable.t['fitsfile'])):
                 if self.imtable.t['fitsfile'][i] != imtable_before.t['fitsfile'][i]:
-                    raise RuntimeError('input file %s in new list is different than previous input file %s' % (self.imtable.t['fitsfile'][i],imtable_before.t['fitsfile'][i]))
+                    raise RuntimeError(('input file %s in new list is different than previous input '
+                                        'file %s' % (self.imtable.t['fitsfile'][i],
+                                                     imtable_before.t['fitsfile'][i])))
 
-            if self.verbose: print('new input list matches previous input list! Continuing...')
+            if self.verbose:
+                print('new input list matches previous input list! Continuing...')
 
-
-        self.imtable.write(imtbl_filename,verbose=True,clobber=True)
+        self.imtable.write(imtbl_filename, verbose=True, clobber=True)
 
         # just some paranoia...
         if not os.path.isfile(imtbl_filename):
@@ -540,7 +566,11 @@ class mkrefsclass(astrotableclass):
                 print('dMJD:', dMJD)
                 if dMJD > max_Delta_MJD:
                     if self.verbose > 2:
-                        print('Skipping imID=%d (MJD=%f) since imID=%d is not within timelimit (Delta MJD = %f>%f)!' % (self.imtable.t['imID'][dindex4detector[i]],self.imtable.t['MJD'][i],self.imtable.t['imID'][dindex4detector[i+1]],dMJD,max_Delta_MJD))
+                        print(('Skipping imID=%d (MJD=%f) since imID=%d is not within timelimit (Delta '
+                               'MJD = %f>%f)!' % (self.imtable.t['imID'][dindex4detector[i]],
+                                                  self.imtable.t['MJD'][i],
+                                                  self.imtable.t['imID'][dindex4detector[i+1]],
+                                                  dMJD, max_Delta_MJD)))
                     i += 1
                     continue
             if self.verbose > 1:
@@ -585,11 +615,15 @@ class mkrefsclass(astrotableclass):
                 if dMJD > max_Delta_MJD:
                     if self.verbose > 2:
                         print(('Skipping imID=%d (MJD=%f) since imID=%d is not within '
-                               'timelimit (Delta MJD = %f>%f)!') % (self.imtable.t['imID'][findex4detector[i]],self.imtable.t['MJD'][i],self.imtable.t['imID'][findex4detector[i+1]],dMJD,max_Delta_MJD))
+                               'timelimit (Delta MJD = %f>%f)!') % (self.imtable.t['imID'][findex4detector[i]],
+                                                                    self.imtable.t['MJD'][i],
+                                                                    self.imtable.t['imID'][findex4detector[i+1]],
+                                                                    dMJD, max_Delta_MJD))
                     i += 1
                     continue
             if self.verbose > 1:
-                print('Adding FF pair with imID=%d and %d' % (self.imtable.t['imID'][findex4detector[i]],self.imtable.t['imID'][findex4detector[i+1]]))
+                print('Adding FF pair with imID=%d and %d' % (self.imtable.t['imID'][findex4detector[i]],
+                                                              self.imtable.t['imID'][findex4detector[i+1]]))
             FF.t.add_row({'F1index': findex4detector[i], 'F2index': findex4detector[i+1],
                           'F1imID': self.imtable.t['imID'][findex4detector[i]],
                           'F2imID': self.imtable.t['imID'][findex4detector[i+1]]})
@@ -617,7 +651,7 @@ class mkrefsclass(astrotableclass):
         for f in range(len(FF.t)):
             if self.verbose > 2:
                 print('# Finding DD pair for FF pair with imID=%d and %d' % (FF.t['F1imID'][f], FF.t['F2imID'][f]))
-            if DDFF_max_Delta_MJD!=None:
+            if DDFF_max_Delta_MJD is not None:
                 FF_MJDmin = np.amin(np.array((self.imtable.t['MJD'][FF.t['F1index'][f]],
                                               self.imtable.t['MJD'][FF.t['F2index'][f]])))
                 FF_MJDmax = np.amax(np.array((self.imtable.t['MJD'][FF.t['F1index'][f]],
@@ -641,7 +675,9 @@ class mkrefsclass(astrotableclass):
                                         DD_MJDmin-FF_MJDmin])
                         max_dMJD = np.amax(dMJD)
                         if max_dMJD > DDFF_max_Delta_MJD:
-                            print('DD pair with imID=%d and %d cannot be used, dMJD=%f>%f' % (DD.t['D1imID'][d], DD.t['D2imID'][d], max_dMJD, DDFF_max_Delta_MJD))
+                            print('DD pair with imID=%d and %d cannot be used, dMJD=%f>%f' % (DD.t['D1imID'][d],
+                                                                                              DD.t['D2imID'][d],
+                                                                                              max_dMJD, DDFF_max_Delta_MJD))
                             continue
                     ddcountmin = ddcount[d]
                     d_best = d
@@ -651,7 +687,10 @@ class mkrefsclass(astrotableclass):
                 print(FF.t[f])
             else:
                 if self.verbose > 2:
-                    print('SUCCESS! DD pair with imID %d and %d found for FF pair with imID %d and %d' % (DD.t['D1imID'][d_best], DD.t['D2imID'][d_best], FF.t['F1imID'][f], FF.t['F2imID'][f]))
+                    print('SUCCESS! DD pair with imID %d and %d found for FF pair with imID %d and %d' % (DD.t['D1imID'][d_best],
+                                                                                                          DD.t['D2imID'][d_best],
+                                                                                                          FF.t['F1imID'][f],
+                                                                                                          FF.t['F2imID'][f]))
                 ddcount[d_best] += 1
                 DDFF.t.add_row({'D1index': DD.t['D1index'][d_best],
                                 'D2index': DD.t['D2index'][d_best],
@@ -752,22 +791,21 @@ class mkrefsclass(astrotableclass):
                                     'detector': detector, 'imlabel': inputimagelabel,
                                     'ssbsteps': self.cfg.params[reflabel]['ssbsteps']}
                         for key in ['fitsfile', 'imID', 'imtype', 'MJD']:
-                            dict2add[key]=self.imtable.t[key][imindex]
+                            dict2add[key] = self.imtable.t[key][imindex]
                         self.inputimagestable.t.add_row(dict2add)
 
                     self.cmdtable.t.add_row({'reflabel': reflabel, 'detector': detector, 'cmdID': cmdID,
                                              'Nim': len(inputimagelabels)})
                     cmdID += 1
 
-
-        if self.verbose>1:
+        if self.verbose > 1:
             print('\n### COMMANDS:')
             print(self.cmdtable.t)
             print('\n### INPUT FILES:')
             print(self.inputimagestable.t)
 
         print('**** ADD: additional check if input images are the same!! ****')
-        self.inputimagestable.write('%s.inputim.txt' % self.basename,verbose=True,clobber=True)
+        self.inputimagestable.write('%s.inputim.txt' % self.basename, verbose=True, clobber=True)
 
         mmm = CalibPrep()
         mmm.inputs = self.inputimagestable.t
@@ -775,7 +813,7 @@ class mkrefsclass(astrotableclass):
         print('Bryan: we need to look for ssb files in the ssb output dir, and then also in the optional pipeline_prod_search_dir. Let me know how I should pass this inof!')
         mmm.search_dir = self.ssbdir
         # add additional search dirs!
-        if self.cfg.params['output']['pipeline_prod_search_dir']!=None:
+        if self.cfg.params['output']['pipeline_prod_search_dir'] is not None:
             mmm.search_dir += ',%s' % (self.cfg.params['output']['pipeline_prod_search_dir'])
 
         mmm.output_dir = self.ssbdir
@@ -812,7 +850,8 @@ class mkrefsclass(astrotableclass):
     def mk_ref_cmds(self):
         for i in range(len(self.cmdtable.t)):
 
-            print('### cmd ID %d: building cmd for %s' % (self.cmdtable.t['cmdID'][i],self.cmdtable.t['reflabel'][i]))
+            print('### cmd ID %d: building cmd for %s' % (self.cmdtable.t['cmdID'][i],
+                                                          self.cmdtable.t['reflabel'][i]))
             # (1) get teh input images from self.inputimagestable
             # (2) parse through the options
 
@@ -827,13 +866,13 @@ class mkrefsclass(astrotableclass):
 
 if __name__ == '__main__':
 
-
     mkrefs = mkrefsclass()
     parser = mkrefs.define_options()
     args = parser.parse_args()
 
     print("Input files:")
     print(args.reflabels_and_imagelist)
+
     #print(args)
     #for b in vars(args):
     #    print(b,vars(args)[b])
@@ -852,9 +891,9 @@ if __name__ == '__main__':
                         params4sections=args.pp)
 
     # set the basedir, basename, ssbdir, outsubdir, runID, runlabel
-    mkrefs.set_dirs(outrootdir = args.outrootdir, outsubdir = args.outsubdir,
-                    runID = args.runID, runIDNdigits = args.runIDNdigits, newrunID = args.newrunID,
-                    ssbdir = args.ssbdir,skip_runID_ssbdir = args.skip_runID_ssbdir)
+    mkrefs.set_dirs(outrootdir=args.outrootdir, outsubdir=args.outsubdir,
+                    runID=args.runID, runIDNdigits=args.runIDNdigits, newrunID=args.newrunID,
+                    ssbdir=args.ssbdir, skip_runID_ssbdir=args.skip_runID_ssbdir)
 
     # get the inputfile list and reflabel list. For input files, get into!
     mkrefs.organize_inputfiles(args.reflabels_and_imagelist)

--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -40,21 +40,21 @@ class cmdsclass(astrotableclass):
 class mkrefsclass(astrotableclass):
     def __init__(self):
         astrotableclass.__init__(self)
-       
+
         #config file
         self.cfg = None
 
         self.verbose = 0
         self.debug = False
         self.onlyshow = False
-        
+
         self.basedir=None
         self.basename=None
         self.outsubdir=None
         self.ssbdir=None
         self.runID=None
         self.runlabel=None
-        
+
         self.imtable = astrotableclass()
         self.images4ssb = astrotableclass()
         #self.darks = None
@@ -68,7 +68,7 @@ class mkrefsclass(astrotableclass):
         self.cmdtable = cmdsclass()
 
         self.allowed_reflabels = ['bpm','rdnoise_nircam','gain_armin']
-        
+
 
     def define_options(self, parser=None, usage=None, conflict_handler='resolve'):
         if parser is None:
@@ -141,14 +141,14 @@ class mkrefsclass(astrotableclass):
             basedir += '/%s' % outsubdir
             if basename != '': basename += '_'
             basename += outsubdir
-            
+
         if runlabel != None:
             basedir += '/%s' % runlabel
             if basename != '': basename += '_'
             basename += runlabel
 
         if basename == '': basename = 'B'
-            
+
         return(basedir,'%s/%s' % (basedir,basename),outsubdir)
 
     def getbasename(self):
@@ -157,7 +157,7 @@ class mkrefsclass(astrotableclass):
             s += '%s/' % self.outsubdir
         if self.runID!=None:
             s += '%s/' % self.outsubdir
-            
+
     def getssbdir(self, ssbdir, basedir, skip_runID_ssbdir = False):
         """ get the ssbdir. It can be hardcoded to a directory with
         --ssbdir or in the cfg file. If it is not specified, then
@@ -169,7 +169,7 @@ class mkrefsclass(astrotableclass):
         else:
             return('%s/ssb' % self.basedir)
         return(None)
-        
+
     def get_highest_runID(self,basedir):
         """ find all subdirs witn run\d+ within the passed basedir, and extract the highest runID"""
         files = glob.glob('%s/run*' % basedir)
@@ -192,7 +192,7 @@ class mkrefsclass(astrotableclass):
 
     def set_runID(self,outrootdir = None, outsubdir = None, runID = None, runIDNdigits = None, newrunID = False):
         """ set the runID depending on the options and config file """
-        
+
         # if no runID is specified with the options, then use the one from the cfg file
         if runID==None:
             runID = mkrefs.cfg.params['output']['runID']
@@ -205,7 +205,7 @@ class mkrefsclass(astrotableclass):
             self.runID = int(runID)
         else:
             # if runID is AUTO, get the current highest runID, and increment if --new_runID (-n)
-            if runID.upper()=='AUTO':        
+            if runID.upper()=='AUTO':
                 (basedir,basename,subdir) = self.getbasedir(outrootdir=outrootdir, outsubdir=outsubdir, runlabel=None)
                 self.runID = self.get_highest_runID(basedir)
                 if self.runID == None:
@@ -221,12 +221,12 @@ class mkrefsclass(astrotableclass):
                 runIDNdigits = self.cfg.params['output']['runIDNdigits']
             if runIDNdigits==None:
                 runIDNdigits=1
-            
+
             b = 'run%0'+'%d' % runIDNdigits+'d'
             self.runlabel = b % (self.runID)
         else:
             self.runlabel = ''
-            
+
         return(self.runID,self.runlabel)
 
     #def getssbdir(self, ssbdir=None, **kwarg):
@@ -239,11 +239,11 @@ class mkrefsclass(astrotableclass):
         # get the runID
         mkrefs.set_runID(outrootdir = outrootdir, outsubdir = outsubdir,
                          runID = runID, runIDNdigits =runIDNdigits, newrunID = newrunID)
-        
+
         (self.basedir,self.basename,self.outsubdir) = self.getbasedir(outrootdir=outrootdir, outsubdir=outsubdir, runlabel=self.runlabel)
 
         self.ssbdir = self.getssbdir(ssbdir,self.basedir, skip_runID_ssbdir = skip_runID_ssbdir)
-        
+
         if self.verbose>=3:
             print('#### Directories:')
             print('basedir:',self.basedir)
@@ -254,7 +254,7 @@ class mkrefsclass(astrotableclass):
             print('runlabel:',self.runlabel)
 
         return(0)
-        
+
     def setoutbasename(self, reftype, imagelist, outbasename=None, outrootdir=None, outsubdir=None,
                        addsuffix=None):
         #if outbasename is not None:
@@ -453,22 +453,22 @@ class mkrefsclass(astrotableclass):
 
             if (len(self.imtable.t['fitsfile']) != len(imtable_before.t['fitsfile'])):
                 raise RuntimeError('length %d of new list of input images is different than the one from the saved table (%d), cannot proceed! either get a new runID with -n, or remove the files in %s' % (len(self.imtable.t['fitsfile']),len(imtable_before.t['fitsfile']),self.basedir))
-                        
+
             for i in range(len(self.imtable.t['fitsfile'])):
                 if self.imtable.t['fitsfile'][i] != imtable_before.t['fitsfile'][i]:
                     raise RuntimeError('input file %s in new list is different than previous input file %s' % (self.imtable.t['fitsfile'][i],imtable_before.t['fitsfile'][i]))
 
             if self.verbose: print('new input list matches previous input list! Continuing...')
-                
-            
+
+
         self.imtable.write(imtbl_filename,verbose=True,clobber=True)
 
         # just some paranoia...
         if not os.path.isfile(imtbl_filename):
             raise RuntimeError('Could not write %s! permission issues?' % (imtbl_filename))
-        
+
         return(0)
-        
+
     def get_optional_arguments(self, args, sysargv):
         fitspattern = re.compile('\.fits$')
 
@@ -759,16 +759,15 @@ class mkrefsclass(astrotableclass):
                                              'Nim': len(inputimagelabels)})
                     cmdID += 1
 
-                    
+
         if self.verbose>1:
             print('\n### COMMANDS:')
             print(self.cmdtable.t)
             print('\n### INPUT FILES:')
             print(self.inputimagestable.t)
-            
+
         print('**** ADD: additional check if input images are the same!! ****')
         self.inputimagestable.write('%s.inputim.txt' % self.basename,verbose=True,clobber=True)
-        sys.exit(0)
 
         mmm = CalibPrep()
         mmm.inputs = self.inputimagestable.t
@@ -780,18 +779,18 @@ class mkrefsclass(astrotableclass):
             mmm.search_dir += ',%s' % (self.cfg.params['output']['pipeline_prod_search_dir'])
 
         mmm.output_dir = self.ssbdir
-        
-        mmm.prepare()
 
+        mmm.prepare()
+        sys.exit()
 
         print('BACK IN MKREFS:')
         print(mmm.proc_table['index','cmdID','reflabel','output_name', 'steps_to_run','repeat_of_index_number','index_contained_within'])
 
         self.ssbcmdtable = astrotableclass()
         self.ssbcmdtable.t = mmm.proc_table
-        self.ssbcmdtable.write('%s.ssbcmds.txt' % self.basename,verbose=True,clobber=True)        
+        self.ssbcmdtable.write('%s.ssbcmds.txt' % self.basename,verbose=True,clobber=True)
 
-        self.cmdtable.write('%s.refcmds.txt' % self.basename,verbose=True,clobber=True)        
+        self.cmdtable.write('%s.refcmds.txt' % self.basename,verbose=True,clobber=True)
 
         #print('strun commands:')
         #print(mmm.strun)
@@ -816,7 +815,7 @@ class mkrefsclass(astrotableclass):
             print('### cmd ID %d: building cmd for %s' % (self.cmdtable.t['cmdID'][i],self.cmdtable.t['reflabel'][i]))
             # (1) get teh input images from self.inputimagestable
             # (2) parse through the options
-            
+
     def combinerefs(self):
         print("### combinerefs: NOT YET IMPLEMENTED!!!")
         sys.exit(0)
@@ -856,11 +855,11 @@ if __name__ == '__main__':
     mkrefs.set_dirs(outrootdir = args.outrootdir, outsubdir = args.outsubdir,
                     runID = args.runID, runIDNdigits = args.runIDNdigits, newrunID = args.newrunID,
                     ssbdir = args.ssbdir,skip_runID_ssbdir = args.skip_runID_ssbdir)
-    
+
     # get the inputfile list and reflabel list. For input files, get into!
     mkrefs.organize_inputfiles(args.reflabels_and_imagelist)
 
-    # check if current input files are consistent with previous ionput files of same output directory! 
+    # check if current input files are consistent with previous ionput files of same output directory!
     mkrefs.check_inputfiles()
     #sys.exit(0)
 

--- a/jwst_reffiles/pipeline/calib_prep.py
+++ b/jwst_reffiles/pipeline/calib_prep.py
@@ -172,7 +172,7 @@ class CalibPrep:
                 print('WARNING: directory %s does not exist!' % self.search_dir)
                 print('WARNING: nothing found!')
                 return([])
-            generator = [os.walk(self.search_dir, topdown=True)]
+            generator = os.walk(self.search_dir, topdown=True)
         elif isinstance(self.search_dir, list):
             # If the search directory is a list, then construct a generator
             # for each directory, and chain them together into a single generator
@@ -714,16 +714,19 @@ class CalibPrep:
         if self.verbose:
             print("Input table updated.")
             print(self.proc_table)
-            ascii.write(self.proc_table, 'test_out.txt', overwrite=True)
-            ascii.write(self.inputs['index',  'repeat_of_index_number', 'index_contained_within', 'steps_to_run', 'real_input_file', 'strun_command'], "test_repeats.txt", overwrite=True)
+            output_table_file = os.path.join(self.output_dir, 'ssb_commands.txt')
+            print(self.output_dir)
+            stop
+            ascii.write(self.proc_table, output_table_file, overwrite=True)
+            #ascii.write(self.inputs['index',  'repeat_of_index_number', 'index_contained_within', 'steps_to_run', 'real_input_file', 'strun_command'], "test_repeats.txt", overwrite=True)
 
         # Table containing only the command ID and the strun command
-        c_tab = Table()
-        c_tab.add_column(self.inputs['cmdID'])
-        c_tab.add_column(self.inputs['strun_command'])
+        #c_tab = Table()
+        #c_tab.add_column(self.inputs['cmdID'])
+        #c_tab.add_column(self.inputs['strun_command'])
 
-        if self.verbose:
-            ascii.write(c_tab, 'test_strun_commands.txt', overwrite=True)
+        #if self.verbose:
+        #    ascii.write(c_tab, 'test_strun_commands.txt', overwrite=True)
 
         # Done
         # calling function can now use self.proc_table and

--- a/jwst_reffiles/pipeline/calib_prep.py
+++ b/jwst_reffiles/pipeline/calib_prep.py
@@ -714,10 +714,9 @@ class CalibPrep:
         if self.verbose:
             print("Input table updated.")
             print(self.proc_table)
-            output_table_file = os.path.join(self.output_dir, 'ssb_commands.txt')
-            print(self.output_dir)
-            stop
-            ascii.write(self.proc_table, output_table_file, overwrite=True)
+            #output_table_file = os.path.join(self.output_dir, 'ssb_commands.txt')
+            #print('output_table_file', output_table_file)
+            #ascii.write(self.proc_table, output_table_file, overwrite=True)
             #ascii.write(self.inputs['index',  'repeat_of_index_number', 'index_contained_within', 'steps_to_run', 'real_input_file', 'strun_command'], "test_repeats.txt", overwrite=True)
 
         # Table containing only the command ID and the strun command

--- a/jwst_reffiles/pipeline/calib_prep.py
+++ b/jwst_reffiles/pipeline/calib_prep.py
@@ -115,6 +115,49 @@ class CalibPrep:
         #              ('jump', 'jump'), ('rampfit', 'rate')]
         self.pipe_step_dict = OrderedDict(PIPE_STEPS)
 
+    def activate_encompassing_entries(self):
+        """Once the search for ssb commands contained within other ssb commands has
+        been completed, go through the list of sets and activate the top level rows
+        that contain other commands. Remember that there can be nested values here.
+        (e.g. row 4 contains [0], row 3 contains [0,4], row 5 contains [0,3,4]) In this
+        example, we want to set the contained_within value to -1 for row 5, as that
+        single run of the pipeline will output products needed by rows 0, 3, and 4 also.
+
+        Rows that do not contain the command for any other rows will have an empty
+        set. These need to be set to -1 as well, so that they are run.
+        """
+        empty_entries = self.inputs['index_contained_within'] == set([])
+        self.inputs['index_contained_within'][empty_entries] = set([-1])
+
+        # Change the entries in the 'index_contained_within' to be lists, for easy
+        # indexing later.
+        new_contained_data = [list(entry) for entry in self.inputs['index_contained_within']]
+        new_contained_column = Column(new_contained_data, name='index_contained_within')
+        self.inputs.remove_column('index_contained_within')
+        self.inputs.add_column(new_contained_column)
+
+    def activate_one_from_repeats(self):
+        """Once the repeat search has been completed, activate only one copy of each
+        repeated entry.
+        """
+        repeats = self.inputs['repeat_of_index_number']
+
+        # Convert to a list so we can find unique elements
+        repeats_list = [sorted(list(s)) for s in repeats]
+        unique_repeats = np.unique(repeats_list)
+
+        for repeat_values in unique_repeats:
+            # Set the first instance of the repeated group to -1 so it will be run.
+            # Leave the other instances as-is so they won't be run
+            self.inputs['repeat_of_index_number'][repeat_values[0]] = set([-1])
+
+        # Change the entries in the 'repeat_of_index_number' to be lists, for easy
+        # indexing later.
+        new_repeat_data = [list(entry) for entry in self.inputs['repeat_of_index_number']]
+        new_repeat_column = Column(new_repeat_data, name='repeat_of_index_number')
+        self.inputs.remove_column('repeat_of_index_number')
+        self.inputs.add_column(new_repeat_column)
+
     def build_search_generator(self):
         '''Create a generator to use for searching for files
 
@@ -141,11 +184,11 @@ class CalibPrep:
                     continue
                 generators.append(os.walk(searchdir, topdown=True))
 
-            #Any entries? If not return None
-            if len(generators)==0:
+            # Any entries? If not return None
+            if len(generators) == 0:
                 print('WARNING: nothing found!')
                 return([])
-                
+
             # Chain together
             generator = itertools.chain()
             for gen in generators:
@@ -204,12 +247,11 @@ class CalibPrep:
         # is a duplicate of another row of the table. The other indicates if the command
         # in one row is contained within the command of another row. Both columns list the
         # index number of the row that it is a duplicate of or contained within.
-        repeat_column = Column(data=np.repeat(-1, len(self.inputs['real_input_file'])),
-                               name='repeat_of_index_number')
+        num_rows = len(self.inputs['real_input_file'])
+        repeat_column = Column(data=[set([i]) for i in range(num_rows)], name='repeat_of_index_number')
         self.inputs.add_column(repeat_column)
 
-        within_column = Column(data=np.repeat(-1, len(self.inputs['real_input_file'])),
-                               name='index_contained_within')
+        within_column = Column(data=[set([]) for i in range(num_rows)], name='index_contained_within')
         self.inputs.add_column(within_column)
 
         # We also need to make a new column to hold the strun commands. After this step,
@@ -217,13 +259,14 @@ class CalibPrep:
         # input, but the maximum string length for the input column has already been set.
         # So we need to make a replacement column with the updated commands so that the new
         # commands aren't truncated at the previous maximum string length
-        #new_commands = [''] * len(self.inputs['strun_command'])
+        # new_commands = [''] * len(self.inputs['strun_command'])
         new_commands = list(self.inputs['strun_command'].data)
 
         for row in self.inputs:
 
             print("Working on row: {}".format(row['index']))
 
+            # Find all entries that have the same INPUT filename
             repeated_filename = self.inputs['real_input_file'] == row['real_input_file']
 
             # Don't count the row itself when looking for matches
@@ -233,6 +276,8 @@ class CalibPrep:
             # If the same starting file is present in more than one row:
             if np.sum(repeated_filename.astype('int')) > 0:
                 matching_rows = self.inputs[repeated_filename]
+
+                print('matching rows:', matching_rows)
 
                 # Strip all whitespace from the list of ssb steps. Use this as
                 # a comparison to see if there are repeats among those with matching
@@ -248,18 +293,27 @@ class CalibPrep:
                         # Save the output name from this row if it is different from the
                         # comparison row.
                         additional_output = matching_row['output_name']
-                        if ((additional_output == outname) & (matching_row['repeat_of_index_number'] == -1) & (current_row_index < row_index)):
+                        if (additional_output == outname):
+                            # (len(matching_row['repeat_of_index_number']) == 0) &
+                            # (current_row_index < row_index)):
                             # Same output filename means the two rows are exact copies
-                            self.inputs[row_index]['repeat_of_index_number'] = current_row_index
+                            self.inputs[row_index]['repeat_of_index_number'].add(current_row_index)
                             #new_commands[row_index] = matching_row['strun_command']
 
                             #print("repeat: setting cmd for row: {}".format(row_index))
-                        elif ((additional_output != outname) & (matching_row['index_contained_within'] == -1)):
+                        elif (additional_output != outname):
                             print("sub-command: setting cmd for row: {}".format(row_index))
                             # Different output names means that to combine these rows we need
                             # to have two outputs. Identify which ssb step the intermediate
                             # output is from, and add it to the strun command
-                            self.inputs[row_index]['index_contained_within'] = current_row_index
+                            print('before', self.inputs['index_contained_within'])
+                            print(row_index)
+
+                            print(self.inputs[row_index:row_index+5]['index_contained_within'])
+                            self.inputs[row_index]['index_contained_within'].add(current_row_index)
+                            print(self.inputs[row_index:row_index+5]['index_contained_within'])
+
+                            print('after', self.inputs['index_contained_within'])
                             final_step = ssbsteps.split(',')[-1]
                             additional_out_str = (" --steps.{}.output_name = {}"
                                                   .format(self.pipe_step_dict[final_step], additional_output))
@@ -269,25 +323,38 @@ class CalibPrep:
                             #print(row['strun_command'])
                             #print('AFTER')
                             #print(row['strun_command'] + additional_out_str)
-                            new_command = row['strun_command'] + additional_out_str
+                            #new_command = row['strun_command'] + additional_out_str
+                            new_command = copy.deepcopy(new_commands[current_row_index]) + additional_out_str
                             new_commands[current_row_index] = new_command
                             #self.inputs[current_row_index]['strun_command'] = new_command
                             #print('AFTER SETTING')
                             #print(self.inputs[current_row_index]['strun_command'])
                         else:
                             print('input names match but no repeat nor subcommand. or already flagged')
-                            #new_commands[row_index] = matching_row['strun_command']
                     else:
                         print('ssb steps is not in or matching other ssbsteps.')
-                        #new_commands[row_index] = matching_row['strun_command']
             else:
                 print("No repeat nor sub-command.")
-                #new_commands[current_row_index] = row['strun_command']
 
         # Now remove the old strun_command column and insert the new one
         self.inputs.remove_column('strun_command')
         new_command_column = Column(data=new_commands, name='strun_command')
+
+        print(self.inputs.colnames)
+        print("Before adding updated commands and dealing with repeats:")
+        print(self.inputs['real_input_file', 'steps_to_run', 'index_contained_within', 'repeat_of_index_number'])
+
         self.inputs.add_column(new_command_column)
+
+        # Activate only one copy of each matching repeat set
+        self.activate_one_from_repeats()
+
+        # Check for subsets in the index_contained_within column, and keep only the entries
+        # that contain all others
+        self.activate_encompassing_entries()
+
+        print("after dealing with contained within:")
+        print(self.inputs['real_input_file', 'steps_to_run', 'index_contained_within', 'repeat_of_index_number'])
 
     def completed_steps(self, input_file):
         '''Identify and return the pipeline steps completed


### PR DESCRIPTION
This PR introduces code that fixes the treatment of repeated entries in the list of SSB commands. The code now handles the case of multiple repeats for a given file. It also now successfully handles cases where a given command is wholly contained within another, and handles nested cases of this.

Notable change from the previous version: the 'repeated' and 'contained_within' columns in the table that is returned by calib_prep.py now contain lists rather than integers. This was done to accommodate  the case where there are multiple repeats or multiple sub-commands. This will be important when deciding which pipeline calls to execute (entries where the repeated and contained_within columns have a value of [-1]).

I also updated the lines that create the output directories, making use of the makepath function in tools.py. This update revealed a bug in the generator created for searching for existing files. That bug was corrected.

I also made some PEP8-related changes.

In a separate PR I will enable logging.