### PR TITLE
Correct output names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
         - os: linux
           env: SETUP_CMD='build_sphinx'
                CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
-               PIP_DEPENDENCIES='sphinx_rtd_theme stsci_rtd_theme sphinx-automodapi'
+               PIP_DEPENDENCIES='sphinx_rtd_theme stsci_rtd_theme sphinx-automodapi nbsphinx'
 
         # PEP8 check with flake8 (only once, i.e. "os: linux")
         - os: linux

--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -40,21 +40,21 @@ class cmdsclass(astrotableclass):
 class mkrefsclass(astrotableclass):
     def __init__(self):
         astrotableclass.__init__(self)
-       
+
         #config file
         self.cfg = None
 
         self.verbose = 0
         self.debug = False
         self.onlyshow = False
-        
+
         self.basedir=None
         self.basename=None
         self.outsubdir=None
         self.ssbdir=None
         self.runID=None
         self.runlabel=None
-        
+
         self.imtable = astrotableclass()
         self.images4ssb = astrotableclass()
         #self.darks = None
@@ -68,7 +68,7 @@ class mkrefsclass(astrotableclass):
         self.cmdtable = cmdsclass()
 
         self.allowed_reflabels = ['bpm','rdnoise_nircam','gain_armin']
-        
+
 
     def define_options(self, parser=None, usage=None, conflict_handler='resolve'):
         if parser is None:
@@ -141,14 +141,14 @@ class mkrefsclass(astrotableclass):
             basedir += '/%s' % outsubdir
             if basename != '': basename += '_'
             basename += outsubdir
-            
+
         if runlabel != None:
             basedir += '/%s' % runlabel
             if basename != '': basename += '_'
             basename += runlabel
 
         if basename == '': basename = 'B'
-            
+
         return(basedir,'%s/%s' % (basedir,basename),outsubdir)
 
     def getbasename(self):
@@ -157,7 +157,7 @@ class mkrefsclass(astrotableclass):
             s += '%s/' % self.outsubdir
         if self.runID!=None:
             s += '%s/' % self.outsubdir
-            
+
     def getssbdir(self, ssbdir, basedir, skip_runID_ssbdir = False):
         """ get the ssbdir. It can be hardcoded to a directory with
         --ssbdir or in the cfg file. If it is not specified, then
@@ -169,7 +169,7 @@ class mkrefsclass(astrotableclass):
         else:
             return('%s/ssb' % self.basedir)
         return(None)
-        
+
     def get_highest_runID(self,basedir):
         """ find all subdirs witn run\d+ within the passed basedir, and extract the highest runID"""
         files = glob.glob('%s/run*' % basedir)
@@ -192,7 +192,7 @@ class mkrefsclass(astrotableclass):
 
     def set_runID(self,outrootdir = None, outsubdir = None, runID = None, runIDNdigits = None, newrunID = False):
         """ set the runID depending on the options and config file """
-        
+
         # if no runID is specified with the options, then use the one from the cfg file
         if runID==None:
             runID = mkrefs.cfg.params['output']['runID']
@@ -205,7 +205,7 @@ class mkrefsclass(astrotableclass):
             self.runID = int(runID)
         else:
             # if runID is AUTO, get the current highest runID, and increment if --new_runID (-n)
-            if runID.upper()=='AUTO':        
+            if runID.upper()=='AUTO':
                 (basedir,basename,subdir) = self.getbasedir(outrootdir=outrootdir, outsubdir=outsubdir, runlabel=None)
                 self.runID = self.get_highest_runID(basedir)
                 if self.runID == None:
@@ -221,12 +221,12 @@ class mkrefsclass(astrotableclass):
                 runIDNdigits = self.cfg.params['output']['runIDNdigits']
             if runIDNdigits==None:
                 runIDNdigits=1
-            
+
             b = 'run%0'+'%d' % runIDNdigits+'d'
             self.runlabel = b % (self.runID)
         else:
             self.runlabel = ''
-            
+
         return(self.runID,self.runlabel)
 
     #def getssbdir(self, ssbdir=None, **kwarg):
@@ -239,11 +239,11 @@ class mkrefsclass(astrotableclass):
         # get the runID
         mkrefs.set_runID(outrootdir = outrootdir, outsubdir = outsubdir,
                          runID = runID, runIDNdigits =runIDNdigits, newrunID = newrunID)
-        
+
         (self.basedir,self.basename,self.outsubdir) = self.getbasedir(outrootdir=outrootdir, outsubdir=outsubdir, runlabel=self.runlabel)
 
         self.ssbdir = self.getssbdir(ssbdir,self.basedir, skip_runID_ssbdir = skip_runID_ssbdir)
-        
+
         if self.verbose>=3:
             print('#### Directories:')
             print('basedir:',self.basedir)
@@ -254,7 +254,7 @@ class mkrefsclass(astrotableclass):
             print('runlabel:',self.runlabel)
 
         return(0)
-        
+
     def setoutbasename(self, reftype, imagelist, outbasename=None, outrootdir=None, outsubdir=None,
                        addsuffix=None):
         #if outbasename is not None:
@@ -453,22 +453,21 @@ class mkrefsclass(astrotableclass):
 
             if (len(self.imtable.t['fitsfile']) != len(imtable_before.t['fitsfile'])):
                 raise RuntimeError('length %d of new list of input images is different than the one from the saved table (%d), cannot proceed! either get a new runID with -n, or remove the files in %s' % (len(self.imtable.t['fitsfile']),len(imtable_before.t['fitsfile']),self.basedir))
-                        
+
             for i in range(len(self.imtable.t['fitsfile'])):
                 if self.imtable.t['fitsfile'][i] != imtable_before.t['fitsfile'][i]:
                     raise RuntimeError('input file %s in new list is different than previous input file %s' % (self.imtable.t['fitsfile'][i],imtable_before.t['fitsfile'][i]))
 
             if self.verbose: print('new input list matches previous input list! Continuing...')
-                
-            
+
         self.imtable.write(imtbl_filename,verbose=True,clobber=True)
 
         # just some paranoia...
         if not os.path.isfile(imtbl_filename):
             raise RuntimeError('Could not write %s! permission issues?' % (imtbl_filename))
-        
+
         return(0)
-        
+
     def get_optional_arguments(self, args, sysargv):
         fitspattern = re.compile('\.fits$')
 
@@ -759,16 +758,14 @@ class mkrefsclass(astrotableclass):
                                              'Nim': len(inputimagelabels)})
                     cmdID += 1
 
-                    
         if self.verbose>1:
             print('\n### COMMANDS:')
             print(self.cmdtable.t)
             print('\n### INPUT FILES:')
             print(self.inputimagestable.t)
-            
+
         print('**** ADD: additional check if input images are the same!! ****')
         self.inputimagestable.write('%s.inputim.txt' % self.basename,verbose=True,clobber=True)
-        sys.exit(0)
 
         mmm = CalibPrep()
         mmm.inputs = self.inputimagestable.t
@@ -780,18 +777,19 @@ class mkrefsclass(astrotableclass):
             mmm.search_dir += ',%s' % (self.cfg.params['output']['pipeline_prod_search_dir'])
 
         mmm.output_dir = self.ssbdir
-        
         mmm.prepare()
 
 
         print('BACK IN MKREFS:')
-        print(mmm.proc_table['index','cmdID','reflabel','output_name', 'steps_to_run','repeat_of_index_number','index_contained_within'])
+        print(mmm.proc_table['index', 'cmdID', 'reflabel', 'output_name', 'steps_to_run', 'repeat_of_index_number', 'index_contained_within'])
+        print(mmm.proc_table['strun_command'][-1])
+        sys.exit()
 
         self.ssbcmdtable = astrotableclass()
         self.ssbcmdtable.t = mmm.proc_table
-        self.ssbcmdtable.write('%s.ssbcmds.txt' % self.basename,verbose=True,clobber=True)        
+        self.ssbcmdtable.write('%s.ssbcmds.txt' % self.basename,verbose=True,clobber=True)
 
-        self.cmdtable.write('%s.refcmds.txt' % self.basename,verbose=True,clobber=True)        
+        self.cmdtable.write('%s.refcmds.txt' % self.basename,verbose=True,clobber=True)
 
         #print('strun commands:')
         #print(mmm.strun)
@@ -816,7 +814,7 @@ class mkrefsclass(astrotableclass):
             print('### cmd ID %d: building cmd for %s' % (self.cmdtable.t['cmdID'][i],self.cmdtable.t['reflabel'][i]))
             # (1) get teh input images from self.inputimagestable
             # (2) parse through the options
-            
+
     def combinerefs(self):
         print("### combinerefs: NOT YET IMPLEMENTED!!!")
         sys.exit(0)
@@ -856,11 +854,11 @@ if __name__ == '__main__':
     mkrefs.set_dirs(outrootdir = args.outrootdir, outsubdir = args.outsubdir,
                     runID = args.runID, runIDNdigits = args.runIDNdigits, newrunID = args.newrunID,
                     ssbdir = args.ssbdir,skip_runID_ssbdir = args.skip_runID_ssbdir)
-    
+
     # get the inputfile list and reflabel list. For input files, get into!
     mkrefs.organize_inputfiles(args.reflabels_and_imagelist)
 
-    # check if current input files are consistent with previous ionput files of same output directory! 
+    # check if current input files are consistent with previous ionput files of same output directory!
     mkrefs.check_inputfiles()
     #sys.exit(0)
 

--- a/jwst_reffiles/pipeline/calib_prep.py
+++ b/jwst_reffiles/pipeline/calib_prep.py
@@ -145,7 +145,7 @@ class CalibPrep:
             if len(generators)==0:
                 print('WARNING: nothing found!')
                 return([])
-                
+
             # Chain together
             generator = itertools.chain()
             for gen in generators:
@@ -379,9 +379,9 @@ class CalibPrep:
             suffix = suffix.replace('uncal_', '')
 
         # Suffix automatically added by the pipeline
-        pipeline_suffix = 'ramp'
+        pipeline_suffix = ''
         if 'rate' not in skip:
-            pipeline_suffix = 'rate'
+            pipeline_suffix = '_rate'
 
         # Remove the entries in skip that are after the last
         # required pipeline step
@@ -408,7 +408,7 @@ class CalibPrep:
 
         # Create the output filename by adding the name of the latest
         # pipeline step to be run
-        ofile = true_base + '_' + suffix + '_' + pipeline_suffix
+        ofile = true_base + '_' + suffix + pipeline_suffix
         ofile = ofile + '.fits'
         output_filename = os.path.join(self.output_dir, ofile)
         return output_filename, true_base
@@ -795,8 +795,8 @@ class CalibPrep:
                 # Add output filename
                 finstep = steps.split(',')[-1]
                 final_step = step_names[finstep]
-                out_text += (' --steps.{}.output_file={}'
-                             .format(final_step, outfile))
+                out_text += (' --steps.{}.output_file={} --steps.{}.output_dir={}'
+                             .format(final_step, outfile, final_step, self.output_dir))
 
                 # Put the whole command together
                 cmd = with_file + skip_text + out_text  # +override_text

--- a/tests/test_calib_prep.py
+++ b/tests/test_calib_prep.py
@@ -156,25 +156,33 @@ def strun_command_test(cp_object):
     torun2 = 'dq,super,ref'
     torun3 = 'dark,lin,rampfit'
     steps_to_run = Column(data=[torun1, torun2, torun3])
-    out_names = ['dummy_jump.fits', 'dummy_refpix.fits', 'dummy_rate.fits']
+    out_names = ['dummy_sat_superbias_dark_jump.fits', 'dummy_dq_init_superbias_refpix.fits',
+                 'dummy_dark_linearity_rate.fits']
+    suffixes = ['sat_superbias_dark_jump', 'dq_init_superbias_refpix', 'dark_linearity_rate']
     output_filename = Column(data=out_names)
     constructed_commands = cp_object.strun_command(input_names, steps_to_run, output_filename)
     truth1 = ('strun calwebb_detector1.cfg {} --steps.dq_init.skip=True --steps.refpix.skip=True '
               '--steps.ipc.skip=True --steps.linearity.skip=True --steps.persistence.skip=True '
-              '--steps.ramp_fitting.skip=True --steps.jump.output_file={} --steps.jump.output_dir={}'
-              ' --steps.refpix.even_odd_rows=False'
-              .format(in_names[0], out_names[0], cp_object.output_dir))
+              '--steps.ramp_fit.skip=True --steps.jump.suffix={} --steps.jump.output_dir={}'
+              ' --steps.jump.save_results=True --save_results=False --steps.refpix.odd_even_rows=False'
+              .format(in_names[0], suffixes[0], cp_object.output_dir))
     truth2 = ('strun calwebb_detector1.cfg {} --steps.saturation.skip=True --steps.ipc.skip=True '
               '--steps.linearity.skip=True --steps.persistence.skip=True --steps.dark_current.skip=True '
-              '--steps.jump.skip=True --steps.ramp_fitting.skip=True --steps.refpix.output_file={}'
-              ' --steps.refpix.output_dir={} --steps.refpix.even_odd_rows=False'
-              .format(in_names[1], out_names[1], cp_object.output_dir))
+              '--steps.jump.skip=True --steps.ramp_fit.skip=True --steps.refpix.suffix={}'
+              ' --steps.refpix.output_dir={} --steps.refpix.save_results=True --save_results=False '
+              '--steps.refpix.odd_even_rows=False'
+              .format(in_names[1], suffixes[1], cp_object.output_dir))
     truth3 = ('strun calwebb_detector1.cfg {} --steps.dq_init.skip=True --steps.saturation.skip=True '
               '--steps.superbias.skip=True --steps.refpix.skip=True --steps.ipc.skip=True '
-              '--steps.persistence.skip=True --steps.jump.skip=True --steps.ramp_fitting.output_file={}'
-              ' --steps.ramp_fitting.output_dir={} --steps.refpix.even_odd_rows=False'
-              .format(in_names[2], out_names[2], cp_object.output_dir))
+              '--steps.persistence.skip=True --steps.jump.skip=True --steps.ramp_fit.suffix={}'
+              ' --steps.ramp_fit.output_dir={} --steps.ramp_fit.save_results=True --save_results=False '
+              '--steps.refpix.odd_even_rows=False'
+              .format(in_names[2], suffixes[2], cp_object.output_dir))
     truths = [truth1, truth2, truth3]
+
+    print(constructed_commands[0])
+    print('')
+    print(truth1)
     assert truths == constructed_commands
 
 

--- a/tests/test_calib_prep.py
+++ b/tests/test_calib_prep.py
@@ -75,7 +75,8 @@ def create_output_test(cp_object):
     """
     requested = create_step_dictionary('dq, sat, ref, super, jump')
     basefilename = 'dark_current_file_number_42_uncal'
-    truth = os.path.join(cp_object.output_dir, basefilename.replace('uncal', 'jump.fits'))
+    base_and_suffix = basefilename.replace('uncal', 'dq_init_saturation_superbias_refpix_jump.fits')
+    truth = os.path.join(cp_object.output_dir, base_and_suffix)
     constructed_name, true_basename = cp_object.create_output(basefilename, requested)
     assert constructed_name == truth
 
@@ -160,16 +161,26 @@ def strun_command_test(cp_object):
     constructed_commands = cp_object.strun_command(input_names, steps_to_run, output_filename)
     truth1 = ('strun calwebb_detector1.cfg {} --steps.dq_init.skip=True --steps.refpix.skip=True '
               '--steps.ipc.skip=True --steps.linearity.skip=True --steps.persistence.skip=True '
-              '--steps.ramp_fitting.skip=True --steps.jump.output_file={}'.format(in_names[0], out_names[0]))
+              '--steps.ramp_fitting.skip=True --steps.jump.output_file={} --steps.jump.output_dir={}'
+              ' --steps.refpix.even_odd_rows=False'
+              .format(in_names[0], out_names[0], cp_object.output_dir))
     truth2 = ('strun calwebb_detector1.cfg {} --steps.saturation.skip=True --steps.ipc.skip=True '
               '--steps.linearity.skip=True --steps.persistence.skip=True --steps.dark_current.skip=True '
               '--steps.jump.skip=True --steps.ramp_fitting.skip=True --steps.refpix.output_file={}'
-              .format(in_names[1], out_names[1]))
+              ' --steps.refpix.output_dir={} --steps.refpix.even_odd_rows=False'
+              .format(in_names[1], out_names[1], cp_object.output_dir))
     truth3 = ('strun calwebb_detector1.cfg {} --steps.dq_init.skip=True --steps.saturation.skip=True '
               '--steps.superbias.skip=True --steps.refpix.skip=True --steps.ipc.skip=True '
               '--steps.persistence.skip=True --steps.jump.skip=True --steps.ramp_fitting.output_file={}'
-              .format(in_names[2], out_names[2]))
+              ' --steps.ramp_fitting.output_dir={} --steps.refpix.even_odd_rows=False'
+              .format(in_names[2], out_names[2], cp_object.output_dir))
     truths = [truth1, truth2, truth3]
+    print(truth1)
+    print(constructed_commands[0])
+    print(truth2)
+    print(constructed_commands[1])
+    print(truth3)
+    print(constructed_commands[2])
     assert truths == constructed_commands
 
 

--- a/tests/test_calib_prep.py
+++ b/tests/test_calib_prep.py
@@ -179,10 +179,6 @@ def strun_command_test(cp_object):
               '--steps.refpix.odd_even_rows=False'
               .format(in_names[2], suffixes[2], cp_object.output_dir))
     truths = [truth1, truth2, truth3]
-
-    print(constructed_commands[0])
-    print('')
-    print(truth1)
     assert truths == constructed_commands
 
 

--- a/tests/test_calib_prep.py
+++ b/tests/test_calib_prep.py
@@ -175,12 +175,6 @@ def strun_command_test(cp_object):
               ' --steps.ramp_fitting.output_dir={} --steps.refpix.even_odd_rows=False'
               .format(in_names[2], out_names[2], cp_object.output_dir))
     truths = [truth1, truth2, truth3]
-    print(truth1)
-    print(constructed_commands[0])
-    print(truth2)
-    print(constructed_commands[1])
-    print(truth3)
-    print(constructed_commands[2])
     assert truths == constructed_commands
 
 


### PR DESCRIPTION
These edits allow all of the pytests to pass. I tweaked the constructed output filenames (for some reason I had all filenames prior to ramp-fitting ending in "_ramp.fits". I removed that. Hopefully I didn't put that there to deal with the pipeline's rules for stripping and replacing suffix pieces.)



