### PR TITLE
Pipelne step order

### DIFF
--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -18,6 +18,7 @@ import scipy
 
 from jwst_reffiles.mkref import mkrefclass
 from jwst_reffiles.pipeline.calib_prep import CalibPrep
+from jwst_reffiles.pipeline import pipeline_steps
 from jwst_reffiles.utils.tools import astrotableclass, yamlcfgclass
 from jwst_reffiles.utils.tools import makepath
 
@@ -730,6 +731,14 @@ class mkrefsclass(astrotableclass):
         if self.verbose:
             print('\n##################################\n### Constructing commands\n##################################')
 
+        # Expand ssbstep list if a shorthand is used
+        for reflabel in self.reflabellist:
+            step_name = self.cfg.params[reflabel]['ssbsteps'].strip()
+            if step_name[-1] == '-':
+                self.cfg.params[reflabel]['ssbsteps'] = pipeline_steps.step_minus(step_name, self.cfg.params['instrument'])
+            elif step_name[-1] == '+':
+                self.cfg.params[reflabel]['ssbsteps'] = pipeline_steps.step_plus(step_name, self.cfg.params['instrument'])
+
         # this is just to get the correct dtype for the reflabel  columns
         dummyreflabel = astrotableclass()
         dummyreflabel.t['reflabel'] = self.reflabellist
@@ -807,7 +816,7 @@ class mkrefsclass(astrotableclass):
         print('**** ADD: additional check if input images are the same!! ****')
         self.inputimagestable.write('%s.inputim.txt' % self.basename, verbose=True, clobber=True)
 
-        mmm = CalibPrep()
+        mmm = CalibPrep(self.cfg.params['instrument'])
         mmm.inputs = self.inputimagestable.t
 
         print('Bryan: we need to look for ssb files in the ssb output dir, and then also in the optional pipeline_prod_search_dir. Let me know how I should pass this inof!')

--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -827,6 +827,8 @@ class mkrefsclass(astrotableclass):
 
         mmm.output_dir = self.ssbdir
         mmm.prepare()
+        print('Table column names:')
+        print(mmm.proc_table.colnames)
         sys.exit()
 
         print('BACK IN MKREFS:')

--- a/jwst_reffiles/pipeline/calib_prep.py
+++ b/jwst_reffiles/pipeline/calib_prep.py
@@ -429,7 +429,6 @@ class CalibPrep:
         step = None
         suffix = 'uncal'
         final_suffix_piece = 'uncal'
-        #skip = list(self.pipe_step_dict.values())
         skip = copy.deepcopy(self.pipe_step_list)
         baseend = len(base)
         for key in self.pipe_step_list:

--- a/jwst_reffiles/pipeline/calib_prep.py
+++ b/jwst_reffiles/pipeline/calib_prep.py
@@ -96,11 +96,12 @@ from astropy.table import Column, Table
 import numpy as np
 from jwst import datamodels
 
-from jwst_reffiles.utils.definitions import PIPE_STEPS, PIPE_KEYWORDS
+from jwst_reffiles.pipeline.pipeline_steps import get_pipeline_steps
+from jwst_reffiles.utils.definitions import PIPE_STEPS, PIPE_KEYWORDS, INSTRUMENTS
 
 
 class CalibPrep:
-    def __init__(self):
+    def __init__(self, instrument):
         self.__version__ = 0.1
         self.verbose = True
         self.inputs = None
@@ -108,12 +109,12 @@ class CalibPrep:
         self.use_only_given = False
         self.overwrite_existing_files = True
         self.output_dir = ''
+        #self.pipe_step_dict = OrderedDict(PIPE_STEPS)
 
-        #pipe_steps = [('dq', 'dq_init'), ('sat', 'saturation'), ('super', 'superbias'),
-        #              ('ref', 'refpix'), ('ipc', 'ipc'), ('lin', 'linearity'),
-        #              ('persistence', 'persistence'), ('dark', 'dark_current'),
-        #              ('jump', 'jump'), ('rampfit', 'rate')]
-        self.pipe_step_dict = OrderedDict(PIPE_STEPS)
+        instrument = instrument.lower()
+        if instrument not in INSTRUMENTS:
+            raise ValueError("WARNING: {} is not a valid instrument name.".format(instrument))
+        self.pipe_step_list = get_pipeline_steps(instrument)
 
     def activate_encompassing_entries(self):
         """Once the search for ssb commands contained within other ssb commands has
@@ -315,8 +316,10 @@ class CalibPrep:
 
                             print('after', self.inputs['index_contained_within'])
                             final_step = ssbsteps.split(',')[-1]
+                            #additional_out_str = (" --steps.{}.output_file = {}"
+                            #                      .format(self.pipe_step_dict[final_step], additional_output))
                             additional_out_str = (" --steps.{}.output_file = {}"
-                                                  .format(self.pipe_step_dict[final_step], additional_output))
+                                                  .format(final_step, additional_output))
                             #print('')
                             #print('')
                             #print('BEFORE')
@@ -369,8 +372,8 @@ class CalibPrep:
         -------
         completed : dict
         '''
-        completed = copy.deepcopy(self.pipe_step_dict)
-        for key in completed:
+        completed = {}
+        for key in self.pipe_step_list:
             completed[key] = False
 
         #starttime = time.time()
@@ -426,14 +429,15 @@ class CalibPrep:
         step = None
         suffix = 'uncal'
         final_suffix_piece = 'uncal'
-        skip = list(self.pipe_step_dict.values())
+        #skip = list(self.pipe_step_dict.values())
+        skip = copy.deepcopy(self.pipe_step_list)
         baseend = len(base)
-        for key in self.pipe_step_dict:
+        for key in self.pipe_step_list:
             if req[key]:
                 step = key
-                suffix = "{}_{}".format(suffix, self.pipe_step_dict[key])
-                final_suffix_piece = self.pipe_step_dict[key]
-                skip.remove(self.pipe_step_dict[key])
+                suffix = "{}_{}".format(suffix, key)
+                final_suffix_piece = key
+                skip.remove(key)
                 # In the case where the filenamne has multiple pipeline step names attached,
                 # walk back until we find the actual basename of the file
                 #if self.pipe_step_dict[key] in base:
@@ -452,7 +456,7 @@ class CalibPrep:
 
         # Remove the entries in skip that are after the last
         # required pipeline step
-        stepvals = np.array(list(self.pipe_step_dict.values()))
+        stepvals = np.array(self.pipe_step_list)
         if final_suffix_piece in stepvals:
             lastmatch = np.where(stepvals == final_suffix_piece)[0][0]
         elif final_suffix_piece == 'uncal':
@@ -754,8 +758,8 @@ class CalibPrep:
         '''
         # Make a copy of pipeline step dictionary and
         # intialize all steps to False
-        req = copy.deepcopy(self.pipe_step_dict)
-        for key in req:
+        req = {}
+        for key in self.pipe_step_list:
             req[key] = False
         if stepstr is None:
             return req
@@ -764,7 +768,7 @@ class CalibPrep:
         # and split into a list
         stepslist = [element.strip() for element in stepstr.split(',')]
         for ele in stepslist:
-            if ele not in list(req.keys()):
+            if ele not in self.pipe_step_list:
                 raise ValueError(("WARNING: unrecognized pipeline step: {}"
                                   .format(ele)))
             try:
@@ -835,8 +839,15 @@ class CalibPrep:
 
         # Quick fix for ramp fitting, which uses a different
         # output suffix than step name, unlike the other steps
-        step_names = copy.deepcopy(self.pipe_step_dict)
-        step_names['rampfit'] = 'ramp_fit'
+
+        #step_names = copy.deepcopy(self.pipe_step_dict)
+        # Create a dictionary of step names and corresponding step class names
+        # In all cases except ramp-fitting, the key and value will be identical
+        step_names = {}
+        for key in self.pipe_step_list:
+            step_names[key] = key
+        # Update the ramp-fitting suffix
+        step_names['rate'] = 'ramp_fit'
 
         cmds = []
 

--- a/jwst_reffiles/pipeline/pipeline_steps.py
+++ b/jwst_reffiles/pipeline/pipeline_steps.py
@@ -1,0 +1,121 @@
+#! /usr/bin/env python
+
+"""This module contains code for retrieving a list of JWST calibration pipeline steps
+to help `jwst_reffiles` define the names and order of the default pipeline steps, such that
+we can make shortcuts (e.g. "slope-" = run all steps in the nominal order up to ramp-fitting)
+"""
+
+# from jwst.pipeline import Detector1Pipeline
+from jwst_reffiles.utils.definitions import INSTRUMENTS
+
+
+def get_pipeline_steps(instrument):
+    """Get the names and order of the calwebb_detector1
+    pipeline steps for a given instrument. Use values that match up with the values in the
+    PIPE_STEP defintion in definitions.py
+
+    Parameters
+    ----------
+
+    instrument : str
+        Name of JWST instrument
+
+    Returns
+    -------
+
+    steps : dict
+        Dictionary of step names (and modules? do we care?)
+    """
+    instrument = instrument.lower()
+    if instrument not in INSTRUMENTS:
+        raise ValueError("WARNING: {} is not a valid instrument name.".format(instrument))
+    # all_steps = Detector1Pipeline.step_defs
+
+    # Order is important in 'steps' lists below!!
+    if instrument == 'miri':
+        steps = ['group_scale', 'dq_init', 'saturation', 'ipc', 'firstframe', 'lastframe',
+                 'linearity', 'rscd', 'dark_current', 'refpix', 'persistence', 'jump', 'rate']
+        # No persistence correction for MIRI
+        steps.remove('persistence')
+    else:
+        steps = ['group_scale', 'dq_init', 'saturation', 'ipc', 'superbias', 'refpix', 'linearity',
+                 'persistence', 'dark_current', 'jump', 'rate']
+
+        # No persistence correction for NIRSpec
+        if instrument == 'nirspec':
+            steps.remove('persistence')
+    return steps
+
+
+def step_minus(step_name, instrument):
+    """Enable "-" shorthand when talking about pipeline steps. For example,
+    "rate-" will indicate all pipeline steps up to (but not including) ramp-fitting.
+    For a given step_name-, return the list of step names to be run.
+
+    Parameters
+    ----------
+
+    step_name : str
+        Name of step name (including the trailing '-')
+
+    instrument : str
+        Name of JWST instrument
+
+    Returns
+    -------
+
+    step_list : list
+        List of step names up to but not including the input step
+    """
+    step_name = step_name.split('-')[0].lower()
+    all_steps = get_pipeline_steps(instrument)
+
+    # Basic error check
+    if step_name not in all_steps:
+        raise ValueError("WARNING: {} is not a valid pipeline step name.".format(step_name))
+
+    step_list = []
+    for step in all_steps:
+        if step == step_name:
+            break
+        else:
+            step_list.append(step)
+
+    # Assuming this will be called by mkrefs, we need to return a comma-separated list of steps
+    step_list_csv = str(step_list).strip('[]').replace("'", "")
+    return step_list_csv
+
+
+def step_plus(step_name, instrument):
+    """Enable "+" shorthand when talking about pipeline steps. For example,
+    "rate+" will indicate all pipeline steps up to and including ramp-fitting.
+    For a given step_name+, return the list of step names to be run.
+
+    Parameters
+    ----------
+
+    step_name : str
+        Name of step name (including the trailing '+')
+
+    instrument : str
+        Name of JWST instrument
+
+    Returns
+    -------
+
+    step_list : list
+        List of step names up to and including the input step
+    """
+    step_name = step_name.split('+')[0].lower()
+    all_steps = get_pipeline_steps(instrument)
+
+    # Basic error check
+    if step_name not in all_steps:
+        raise ValueError("WARNING: {} is not a valid pipeline step name.".format(step_name))
+
+    location = all_steps.index(step_name)
+    step_list = all_steps[0:location + 1]
+
+    # Assuming this will be called by mkrefs, we need to return a comma-separated list of steps
+    step_list_csv = str(step_list).strip('[]').replace("'", "")
+    return step_list_csv

--- a/jwst_reffiles/utils/definitions.py
+++ b/jwst_reffiles/utils/definitions.py
@@ -6,14 +6,27 @@ pipeline step
 
 # Abbreviations for pipeline steps. The abbreviations (keys) here, must be used
 # in the configuration files when listing pipeline steps
-PIPE_STEPS = [('dq', 'dq_init'), ('sat', 'saturation'), ('super', 'superbias'),
-              ('ref', 'refpix'), ('ipc', 'ipc'), ('lin', 'linearity'),
-              ('persistence', 'persistence'), ('dark', 'dark_current'),
-              ('jump', 'jump'), ('rampfit', 'rate')]
+#PIPE_STEPS = [('dq', 'dq_init'), ('sat', 'saturation'), ('super', 'superbias'),
+#              ('ref', 'refpix'), ('ipc', 'ipc'), ('lin', 'linearity'),
+#              ('persistence', 'persistence'), ('dark', 'dark_current'),
+#              ('jump', 'jump'), ('rampfit', 'rate')]
+
+# Abbreviations for pipeline steps. These are the values used in the JWST calibration
+# pipeline, and are also the values that must be used in jwst_reffiles input configuration
+# files
+PIPE_STEPS = ['group_scale', 'dq_init', 'saturation', 'ipc', 'firstframe', 'lastframe',
+              'superbias', 'refpix', 'linearity', 'persistence', 'rscd', 'dark_current',
+              'jump', 'rate']
 
 # Define header keyword that accompanies each step
 # This needs to be made more instrument-agnostic. The list is going to
 # vary depending on instrument.
-PIPE_KEYWORDS = {'S_DQINIT': 'dq', 'S_SATURA': 'sat', 'S_REFPIX': 'ref', 'S_SUPERB': 'super',
-                 'S_IPC': 'ipc', 'S_PERSIS': 'persistence', 'S_DARK': 'dark', 'S_LINEAR': 'lin',
-                 'S_JUMP': 'jump',  'S_RAMP': 'rampfit'}
+#PIPE_KEYWORDS = {'S_DQINIT': 'dq', 'S_SATURA': 'sat', 'S_REFPIX': 'ref', 'S_SUPERB': 'super',
+#                 'S_IPC': 'ipc', 'S_PERSIS': 'persistence', 'S_DARK': 'dark', 'S_LINEAR': 'lin',
+#                 'S_JUMP': 'jump',  'S_RAMP': 'rampfit'}
+
+PIPE_KEYWORDS = {'S_DQINIT': 'dq_init', 'S_SATURA': 'saturation', 'S_REFPIX': 'refpix', 'S_SUPERB': 'superbias',
+                 'S_IPC': 'ipc', 'S_PERSIS': 'persistence', 'S_DARK': 'dark_current', 'S_LINEAR': 'linearlity',
+                 'S_JUMP': 'jump',  'S_RAMP': 'rate'}
+
+INSTRUMENTS = ['nircam', 'niriss', 'nirspec', 'miri', 'fgs']

--- a/jwst_reffiles/utils/definitions.py
+++ b/jwst_reffiles/utils/definitions.py
@@ -4,13 +4,6 @@
 pipeline step
 """
 
-# Abbreviations for pipeline steps. The abbreviations (keys) here, must be used
-# in the configuration files when listing pipeline steps
-#PIPE_STEPS = [('dq', 'dq_init'), ('sat', 'saturation'), ('super', 'superbias'),
-#              ('ref', 'refpix'), ('ipc', 'ipc'), ('lin', 'linearity'),
-#              ('persistence', 'persistence'), ('dark', 'dark_current'),
-#              ('jump', 'jump'), ('rampfit', 'rate')]
-
 # Abbreviations for pipeline steps. These are the values used in the JWST calibration
 # pipeline, and are also the values that must be used in jwst_reffiles input configuration
 # files
@@ -18,15 +11,11 @@ PIPE_STEPS = ['group_scale', 'dq_init', 'saturation', 'ipc', 'firstframe', 'last
               'superbias', 'refpix', 'linearity', 'persistence', 'rscd', 'dark_current',
               'jump', 'rate']
 
-# Define header keyword that accompanies each step
-# This needs to be made more instrument-agnostic. The list is going to
-# vary depending on instrument.
-#PIPE_KEYWORDS = {'S_DQINIT': 'dq', 'S_SATURA': 'sat', 'S_REFPIX': 'ref', 'S_SUPERB': 'super',
-#                 'S_IPC': 'ipc', 'S_PERSIS': 'persistence', 'S_DARK': 'dark', 'S_LINEAR': 'lin',
-#                 'S_JUMP': 'jump',  'S_RAMP': 'rampfit'}
+# Define the fits header keyword that accompanies each step
+PIPE_KEYWORDS = {'S_GRPSCL': 'group_scale', 'S_DQINIT': 'dq_init', 'S_SATURA': 'saturation',
+                 'S_REFPIX': 'refpix', 'S_SUPERB': 'superbias', 'S_IPC': 'ipc', 'S_PERSIS': 'persistence',
+                 'S_DARK': 'dark_current', 'S_LINEAR': 'linearlity', 'S_FRSTFR': 'firstframe',
+                 'S_LASTFR': 'lastframe', 'S_RSCD': 'rscd', 'S_JUMP': 'jump',  'S_RAMP': 'rate'}
 
-PIPE_KEYWORDS = {'S_DQINIT': 'dq_init', 'S_SATURA': 'saturation', 'S_REFPIX': 'refpix', 'S_SUPERB': 'superbias',
-                 'S_IPC': 'ipc', 'S_PERSIS': 'persistence', 'S_DARK': 'dark_current', 'S_LINEAR': 'linearlity',
-                 'S_JUMP': 'jump',  'S_RAMP': 'rate'}
-
+# List of available instruments
 INSTRUMENTS = ['nircam', 'niriss', 'nirspec', 'miri', 'fgs']


### PR DESCRIPTION
This PR introduces several changes to the code.

First, it enables the use of "step_name-" and "step_name+" when listing calibration steps to do. "step_name-" includes all pipeline steps up to, but not including, step_name.
"step_name+" includes all pipeline steps up to and including, step_name.
This is mainly for users' convenience so they don't have to type out a long list of step names. The + and - names will be expanded within `mkrefs.py`, such that the tables produced by mkrefs will explicitly list all pipeline steps to be done.

Second, these code edits change the allowed pipeline step abbreviations in the input config files. The only allowed abbreviations are those used by the calibration pipeline itself (e.g. "dq_init" rather than "dq"). To see the list of possible abbreviations, see `pipeline_steps.py` in the `pipeline` subdirectory.

Third, when creating an instance of a CalibPrep object, there is now 1 required input (previously there were none). That is the name of the instrument. This is needed in order to generate the correct list of pipeline steps, as these vary by instrument. See the instantiation in `mkrefs.py` for an example.

(We may wish to add more parameters as inputs to `__init__` in `calib_prep.py`. This may make calling it easier. Something for a separate PR though.

@arminrest, I have tested this by examining the output table created by `calib_prep.py`. That looks good to me. The results of searching for repeated commands is identical to the previous version of the code. I have not tried running any of the strun commands produced by these changes. I believe the step names and suffixes are correct, but testing is required to be sure. But I think for the sake of the current state of development, this seems to be working well. If you agree and you want to start working off of this code, feel free to approve and merge.