### PR TITLE
Redefine step-, enforce pipeline default step order

### DIFF
--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -829,6 +829,9 @@ class mkrefsclass(astrotableclass):
         mmm.prepare()
         print('Table column names:')
         print(mmm.proc_table.colnames)
+        #print(mmm.proc_table['ssbsteps'])
+        #print(mmm.proc_table['steps_to_run'])
+        #print(mmm.proc_table['output_name'])
         sys.exit()
 
         print('BACK IN MKREFS:')

--- a/jwst_reffiles/pipeline/calib_prep.py
+++ b/jwst_reffiles/pipeline/calib_prep.py
@@ -393,7 +393,7 @@ class CalibPrep:
                 value = header.get(key)
                 if value == 'COMPLETE':
                     completed[PIPE_KEYWORDS[key]] = True
-        return completed
+        return OrderedDict(completed)
 
     def create_output(self, base, req):
         '''Create the output name of the pipeline-processed
@@ -761,7 +761,7 @@ class CalibPrep:
         for key in self.pipe_step_list:
             req[key] = False
         if stepstr is None:
-            return req
+            return OrderedDict(req)
 
         # Strip all whitespace from the list of steps
         # and split into a list
@@ -774,7 +774,7 @@ class CalibPrep:
                 req[ele] = True
             except KeyError as error:
                 print(error)
-        return req
+        return OrderedDict(req)
 
     def steps_to_run(self, infile, req, current):
         '''Return a list of the pipeline steps that need
@@ -842,7 +842,7 @@ class CalibPrep:
         #step_names = copy.deepcopy(self.pipe_step_dict)
         # Create a dictionary of step names and corresponding step class names
         # In all cases except ramp-fitting, the key and value will be identical
-        step_names = {}
+        step_names = OrderedDict({})
         for key in self.pipe_step_list:
             step_names[key] = key
         # Update the ramp-fitting suffix

--- a/jwst_reffiles/pipeline/pipeline_steps.py
+++ b/jwst_reffiles/pipeline/pipeline_steps.py
@@ -49,7 +49,7 @@ def get_pipeline_steps(instrument):
 
 def step_minus(step_name, instrument):
     """Enable "-" shorthand when talking about pipeline steps. For example,
-    "rate-" will indicate all pipeline steps up to (but not including) ramp-fitting.
+    "rate-" will indicate all pipeline steps up to and including ramp-fitting.
     For a given step_name-, return the list of step names to be run.
 
     Parameters
@@ -65,48 +65,9 @@ def step_minus(step_name, instrument):
     -------
 
     step_list : list
-        List of step names up to but not including the input step
-    """
-    step_name = step_name.split('-')[0].lower()
-    all_steps = get_pipeline_steps(instrument)
-
-    # Basic error check
-    if step_name not in all_steps:
-        raise ValueError("WARNING: {} is not a valid pipeline step name.".format(step_name))
-
-    step_list = []
-    for step in all_steps:
-        if step == step_name:
-            break
-        else:
-            step_list.append(step)
-
-    # Assuming this will be called by mkrefs, we need to return a comma-separated list of steps
-    step_list_csv = str(step_list).strip('[]').replace("'", "")
-    return step_list_csv
-
-
-def step_plus(step_name, instrument):
-    """Enable "+" shorthand when talking about pipeline steps. For example,
-    "rate+" will indicate all pipeline steps up to and including ramp-fitting.
-    For a given step_name+, return the list of step names to be run.
-
-    Parameters
-    ----------
-
-    step_name : str
-        Name of step name (including the trailing '+')
-
-    instrument : str
-        Name of JWST instrument
-
-    Returns
-    -------
-
-    step_list : list
         List of step names up to and including the input step
     """
-    step_name = step_name.split('+')[0].lower()
+    step_name = step_name.split('-')[0].lower()
     all_steps = get_pipeline_steps(instrument)
 
     # Basic error check


### PR DESCRIPTION
These code changes affect two topics:

1) step_name- is redefined so that the pipeline runs all steps up to and including step_name. (e.g. "saturation-" would run gain_scale, dq_init, and saturation)

2) I changed several dictionaries to OrderedDcitionaries, so that the order of the steps within the pipeline always matches the default order. We hope to change this later, but in the interest of getting the code working, we insist on the pipeline default order for now.

@arminrest , hopefully this will clear up the out of order steps you were seeing. My test cases are all in the correct order when using this code.

