### PR TITLE
strun execution

### DIFF
--- a/jwst_reffiles/mkrefs.cfg
+++ b/jwst_reffiles/mkrefs.cfg
@@ -48,7 +48,14 @@ output:
    # if skip_runID_ssbdir, then the runID is skipped
    ssbdir:
    skip_runID_ssbdir: False
-
+   # If ssblogFlag=True, the stdout from the strun command is saved in a log
+   # file, same name as reduced filename, but with suffix log.txt
+   ssblogFlag: True
+   # If ssberrorlogFlag=True, the stderr from the strun command is
+   # saved in a log file, same name as reduced filename, but with
+   # suffix err.txt
+   ssberrorlogFlag: True
+   
    # directories in which ssb products are looked for. comma-separated list!
    pipeline_prod_search_dir:
 

--- a/jwst_reffiles/mkrefs.cfg
+++ b/jwst_reffiles/mkrefs.cfg
@@ -1,5 +1,6 @@
 instrument: NIRCam
 reflabels: [gain_armin,bpm,rdnoise_nircam]
+reftypes: [bpm,rdnoise,gain,linearity]
 
 default_reflabels:
    bpm: bpm
@@ -60,8 +61,9 @@ test1: 4
 
 # values allowed: CRDS, SELF, filepattern
 reffile4ssb:
-   gainreffile: CRDS
-   bpmreffile: CRDS
+   gain: CRDS
+   bpm: CRDS
+   rdnoise: CRDS
 
 # values allowed: CRDS, filename
 validation:
@@ -71,26 +73,26 @@ validation:
 bpm:
     reftype: bpm
     imtypes: D
-    ssbsteps: dq,ref
+    ssbsteps: refpix-
 
 
 rdnoise_nircam:
     reftype: rdnoise
     imtypes: DD
-    ssbsteps: dq,ref
+    ssbsteps: dq_init
     test1: 6
 
 gain_armin:
     reftype: gain
     imtypes: DDFF
-    ssbsteps: dq,ref,super
+    ssbsteps: superbias-
     reffile4ssb:
         bpmreffile: /bla/bpm.fits
 
 gain_bryan:
     reftype: gain
     imtypes: FF
-    ssbsteps: dq,ref
+    ssbsteps: rate-
     reffile4ssb:
         bpmreffile: /bla/bpm.fits
 

--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -829,7 +829,6 @@ class mkrefsclass(astrotableclass):
         mmm.prepare()
         print('Table column names:')
         print(mmm.proc_table.colnames)
-        #sys.exit()
 
         #print('BACK IN MKREFS:')
         #print(mmm.proc_table['index', 'cmdID', 'reflabel', 'output_name', 'steps_to_run', 'repeat_of_index_number', 'index_contained_within'])

--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -724,7 +724,7 @@ class mkrefsclass(astrotableclass):
             raise RuntimeError("ERROR: imtypes=%s not yet implemented!" % imtypes)
         return(imagesets, imagelabels)
 
-    def mk_ssb_cmds(self):
+    def mk_ssb_cmds(self,force_redo_ssb=False):
         '''
         Construct the reflabel commands, get the input files
         '''
@@ -829,27 +829,35 @@ class mkrefsclass(astrotableclass):
         mmm.prepare()
         print('Table column names:')
         print(mmm.proc_table.colnames)
-        #print(mmm.proc_table['ssbsteps'])
-        #print(mmm.proc_table['steps_to_run'])
-        #print(mmm.proc_table['output_name'])
-        sys.exit()
+        #sys.exit()
 
-        print('BACK IN MKREFS:')
-        print(mmm.proc_table['index', 'cmdID', 'reflabel', 'output_name', 'steps_to_run', 'repeat_of_index_number', 'index_contained_within'])
-        print(mmm.proc_table['strun_command'][-1])
-        sys.exit()
+        #print('BACK IN MKREFS:')
+        #print(mmm.proc_table['index', 'cmdID', 'reflabel', 'output_name', 'steps_to_run', 'repeat_of_index_number', 'index_contained_within'])
+        #print(mmm.proc_table['strun_command'][-1])
+        #sys.exit()
 
         self.ssbcmdtable = astrotableclass()
         self.ssbcmdtable.t = mmm.proc_table
+
+        self.check_if_inputfiles_exists()
+
         self.ssbcmdtable.write('%s.ssbcmds.txt' % self.basename,verbose=True,clobber=True)
 
         self.cmdtable.write('%s.refcmds.txt' % self.basename,verbose=True,clobber=True)
 
+        sys.exit(0)
+        
         #print('strun commands:')
         #print(mmm.strun)
 
         return(0)
 
+    def check_if_inputfiles_exists(self,outcol='file_exists'):
+        print('XXXX %d' % len(self.ssbcmdtable.t))
+        file_exists = np.full((len(self.ssbcmdtable.t)),False)
+        print(file_exists)
+        sys.exit(0)
+        
     def run_ssb_cmds(self,batchmode=False):
         print("### run ssb commands: NOT YET IMPLEMENTED!!!")
         return(0)

--- a/jwst_reffiles/pipeline/calib_prep.py
+++ b/jwst_reffiles/pipeline/calib_prep.py
@@ -631,7 +631,8 @@ class CalibPrep:
             # has not allowed the removal of files, throw an error.
             # Similarly, if permissions prevent you from successfully
             # removing the file, throw an error
-            self.output_exist_check(os.path.join(self.output_dir, outname))
+            # AR: I remove this! We don't want to remove files that already exist! Only if --force_redo_ssb
+            #self.output_exist_check(os.path.join(self.output_dir, outname))
 
             # Search the self.search_dir directories for partially
             # processed files.

--- a/jwst_reffiles/utils/tools.py
+++ b/jwst_reffiles/utils/tools.py
@@ -5,14 +5,17 @@ In addition: config file using yaml
 A. Rest
 '''
 
-import os
+import os,io
 import re
 import sys
 import types
+import subprocess
+import pytz
 
 import astropy
 from astropy.io import ascii
 from astropy.time import Time
+from datetime import datetime
 import astropy.io.fits as fits
 import numpy as np
 from numpy import recarray
@@ -40,30 +43,211 @@ def makepath4file(filename, raiseError=True):
     else:
         return(0)
 
-def executecommand(cmd,successword,errorlog=None,cmdlog=None,verbose=1):
-    if verbose: print('executing: %s' % cmd)
-    (cmd_in,cmd_out)=os.popen4(cmd)
-    output = cmd_out.readlines()
-    if successword=='':
-        successflag = 1
+def save2file(filename,lines,verbose=0):
+    if os.path.lexists(filename):
+        os.remove(filename)
+    if os.path.isfile(filename):
+        raise RuntimeError('ERROR: Cannot remove %s' % filename)
+    errorcode = append2file(filename,lines,verbose=verbose)
+    return(errorcode)
+    
+def append2file(filename,lines,verbose=0):
+    if filename==None:
+        if verbose>2: print('No filename, returning')
+        return(0)
+    
+    if isinstance(lines,str):
+        lines = [lines,]
+    if lines==None:
+        return(0)
+    if len(lines)==0:
+        return(0)
+
+    if os.path.isfile(filename):
+        if verbose:print('Appending to file %s' % filename)
+        buff = open(filename, 'a')
     else:
-        m = re.compile(successword)
+        if verbose:print('Writing to file %s' % filename)
+        buff = open(filename, 'w')
+        
+    r=re.compile('\n$')
+    #if first line does not have a \n, assume none of them have and add it!
+    if not r.search(lines[0]):
+       for i in range(len(lines)):
+           lines[i]+='\n'
+
+    buff.writelines(lines)
+    buff.close()
+
+    return(0)
+
+def rmfile(filename,raiseError=1):
+    " if file exists, remove it "
+    if os.path.lexists(filename):
+        os.remove(filename)
+        if os.path.isfile(filename):
+            if raiseError == 1:
+                raise RuntimeError('Cannot remove {}'.format(filename))
+            else:
+                print('ERROR: Cannot remove {}'.format(filename))
+                return(1)
+    return(0)
+
+def executecommand(cmd,successword,shell=True, errorlog=None, cmdlog=None, clobbercmdlog=False,
+                   cmdlog_access_mode='w', errorlog_access_mode='a', cmdlog_save_as_chunk_flag = True,
+                   log_buffering=-1, return_output=False, 
+                   verbose=2,
+                   timezone='US/Eastern'):
+    """ execute the given command cmd as a shell command.
+
+    cmdlog and errorlog can be a filename or a file handle.
+    
+    clobbercmdlog=True and cmdlog_access_mode only apply if cmdlog is
+    a filename. log_access_mode can be all allowed access_mode values
+    for subprocess.Popen.  if clobbercmdlog=True, the cmdlog file is
+    deleted before logging begins, even if cmdlog_access_mode='a'.
+
+    if cmdlog!=None: As default, cmdlog_save_as_chunk_flag=True, which
+    means that the output of the cmd is save in cmdlog *after* the
+    command is finished. If there is an error, it could be that then
+    the output is not saved in the cmdlog, thus for debugging, the
+    user can set cmdlog_save_as_chunk_flag=False, and then each
+    individual output line is immediately saved into cmdlog
+
+    The output of the command is shown on screen in real-time if
+    verbose>1.
+
+    The errorlog captures the stderr output. By default, old errors
+    are not deleted (i.e. errorlog_access_mode='a'). If there is an
+    error, this routine returns 1 
+
+    if return_output=True, then the stdout and stderr are returned as
+    lists: (returncode,stdout_lines,stderr_lines). Otherwise, only
+    retruncode is returned
+
+    """
+
+    errorcode=0
+
+    time_cmdstart = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    if verbose: print('{} executing: {}'.format(time_cmdstart,cmd))
+    
+    # check if logs are strings or file handles
+    print(type(cmdlog))
+    if cmdlog!=None:
+        if isinstance(cmdlog,str):
+            if clobbercmdlog:
+                rmfile(cmdlog)
+            cmdlog_filehandle = open(cmdlog, cmdlog_access_mode, log_buffering)
+        elif isinstance(cmdlog,io.IOBase):
+            if clobbercmdlog:
+                raise RuntimeError('Cannot clobber a filehandle (cmdlog)')
+            cmdlog_filehandle = cmdlog
+        else:
+            raise RuntimeError('Can\'t understand cmdlog')
+        cmdlog_filehandle.write('{} executing: {}\n'.format(time_cmdstart,cmd))
+    else:
+        cmdlog_filehandle = None
+
+    if errorlog!=None:
+        if isinstance(errorlog,str):
+            errorlog_filehandle = open(errorlog, errorlog_access_mode, log_buffering)
+        elif isinstance(errorlog,io.IOBase):
+            errorlog_filehandle = errorlog
+        else:
+            raise RuntimeError('Can\'t understand errorlog')
+    else:
+        errorlog_filehandle = None
+        
+
+    # start the subprocess...
+    p = subprocess.Popen(cmd,shell=shell,stdout=subprocess.PIPE,stderr=subprocess.PIPE, close_fds=True)
+
+    # capture the output while the subprocess is running
+    if verbose>1:
+        print('Output:')
+    stdout_lines=[]
+
+    # Use a regular expression to search for a word that indicate that the command executed successfully: set successflag=0, and compile the search expression. 
+    if successword!='':
         successflag = 0
-        for line in output:
-            if m.search(line):
-                successflag = 1
-    errorflag = not successflag
-    if errorflag:
-        print('error: executing %s' % cmd)
-        if errorlog != None:
-            append2file(errorlog,['\n error executing: '+cmd+'\n'])
-            append2file(errorlog,output)
-        if cmdlog != None:
-            append2file(cmdlog,['\n error executing:',cmd])
+        m = re.compile(successword)
     else:
-        if cmdlog != None:
-            append2file(cmdlog,[cmd])
-    return errorflag, output
+        successflag = 1
+        m = None
+        
+    while p.poll()==None:
+            l1 = p.stdout.readline()
+            if l1==b'':
+                continue
+            l=l1.decode('UTF-8').strip()
+            if verbose>1: print(l)
+            if cmdlog_filehandle != None or errorlog_filehandle != None:
+                if l!='': 
+                    if cmdlog_save_as_chunk_flag or errorlog_filehandle != None or return_output:
+                        stdout_lines.append(l+'\n')
+                    if not cmdlog_save_as_chunk_flag:
+                        #cmdlog_filehandle.write(l1)
+                        cmdlog_filehandle.write(l+'\n')
+
+            # check if the success word is in the output.
+            if m!=None and successflag ==0:
+                if m.search(l):
+                    successflag = 1
+                
+            
+    # Done!
+    time_cmdend = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    endstring = 'execution finished ({} to {}): {}'.format(time_cmdstart,time_cmdend,cmd)
+    if verbose:
+        print(endstring)
+
+    # if wanted, save the output into the cmdlog
+    if cmdlog_filehandle != None:
+        if cmdlog_save_as_chunk_flag:
+            cmdlog_filehandle.writelines(stdout_lines)
+        cmdlog_filehandle.write(endstring+'\n')
+            
+    # check for errors!
+    stderr_lines = p.stderr.readlines()
+
+    # Coulnd't find success word? add to the error messages...
+    if successflag!=1:
+        errline = 'ERROR: could not find success expression {} in the output!'.format(successword)
+        print(errline)
+        stderr_lines.append('{}\n'.format(errline).encode())
+
+    # if errors, print them again and save in errorlog
+    if len(stderr_lines)>0:
+
+        errline = '\n* THERE WERE ERRORS IN THE EXECUTION OF CMD ({} to {}): {}'.format(time_cmdstart,time_cmdend,cmd)
+        print(errline)
+        if errorlog_filehandle != None:
+            #errorlog_filehandle.write('{}\n'.format(errline).encode())
+            errorlog_filehandle.write(errline+'\n')
+        print('* Error messages:')
+        for l1 in stderr_lines:
+            l=l1.decode('UTF-8').strip()
+            print('*',l)
+            if errorlog_filehandle != None:
+                errorlog_filehandle.write(l+'\n')
+        errorcode = 1
+        
+    # close the files
+    if cmdlog_filehandle != None:
+        # if the file handle was opened within routine, close it. if the filehandle was passed, don't close it
+        if isinstance(cmdlog,str):
+            cmdlog_filehandle.close()
+    if errorlog_filehandle != None:
+        # if the file handle was opened within routine, close it. if the filehandle was passed, don't close it
+        if isinstance(errorlog,str):
+            errorlog_filehandle.close()
+
+    if return_output:
+        return(errorcode,stdout_lines,stderr_lines)
+    else:
+        return(errorcode)
+        
 
 class yamlcfgclass:
     def __init__(self):

--- a/jwst_reffiles/utils/tools.py
+++ b/jwst_reffiles/utils/tools.py
@@ -40,6 +40,30 @@ def makepath4file(filename, raiseError=True):
     else:
         return(0)
 
+def executecommand(cmd,successword,errorlog=None,cmdlog=None,verbose=1):
+    if verbose: print('executing: %s' % cmd)
+    (cmd_in,cmd_out)=os.popen4(cmd)
+    output = cmd_out.readlines()
+    if successword=='':
+        successflag = 1
+    else:
+        m = re.compile(successword)
+        successflag = 0
+        for line in output:
+            if m.search(line):
+                successflag = 1
+    errorflag = not successflag
+    if errorflag:
+        print('error: executing %s' % cmd)
+        if errorlog != None:
+            append2file(errorlog,['\n error executing: '+cmd+'\n'])
+            append2file(errorlog,output)
+        if cmdlog != None:
+            append2file(cmdlog,['\n error executing:',cmd])
+    else:
+        if cmdlog != None:
+            append2file(cmdlog,[cmd])
+    return errorflag, output
 
 class yamlcfgclass:
     def __init__(self):


### PR DESCRIPTION
This is mainly to keep track of the bookkeeping when executing the strun commands. I added executecommand() into tools. commands that get executed in serial are executed through this command, which does the following:

- The output of the command is shown on screen in real-time if verbose>1.
- stdout and stderr can be saved in files (access_mode "w" and "a" possible)
- The log file entries have time stamps
- the suffixes of the log files are log.txt and err.txt, with the basename the ssb reduced filename
- error checking.
- you can optionally pass a "successword", i.e. the output of the command is checked for that regular expression, and the command execution is only successful if it finds this expression. This is a very good way of making sure black boxes ran all the way to completion. 

I added to options: --force_redo_strun --maxNstrun=1

in ssbcmdtable: column "execute_strun" indicates which of the strun commands will be executed. "strun_executed" indicates which strun commands got executed/are in batch: column values are "serial","batch",None,"ERRORX_serial". The X in Error is the error code.

bugs with ssb code:

- calwebb_detector1.cfg does not have the path, thus it cannot execute the strun commands
- When Bryan's code looks for already reduced files, it doesn't check the suffix, thus it picks up the log files and tries to read the fits header, which of course fails.

I think otherwise we are ready to go!

 
