### PR TITLE
Add paths and suffixes

### DIFF
--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -107,7 +107,7 @@ class mkrefsclass(astrotableclass):
         parser.add_argument('--maxNstrun', type=int, default=None,
                             help='limit the number of strun commands to be run')
 
-        
+
         # Loop through all allowed reflabels, and add the options
         for reflabel in self.allowed_reflabels:
             print(reflabel)
@@ -742,7 +742,7 @@ class mkrefsclass(astrotableclass):
             # Don't redo it if file already exists and if it is not force_redo_strun
             if (not force_redo_strun) and self.ssbcmdtable.t['file_exists'][i]:
                 exeflag=False
-            
+
             if self.ssbcmdtable.t['already_in_batch'][i]:
                 exeflag=False
                 # force_redo_strun? Cannot do that, otherwise all hell would break loose with overwriting files etc
@@ -756,9 +756,9 @@ class mkrefsclass(astrotableclass):
 
             if exeflag:
                 Nstrun+=1
-                   
+
             execute_strun[i]=exeflag
-            
+
         self.ssbcmdtable.t[execute_strun_col]=execute_strun
         return(0)
 
@@ -901,9 +901,9 @@ class mkrefsclass(astrotableclass):
         print(mmm.proc_table.colnames)
 
         #print('BACK IN MKREFS:')
-        #print(mmm.proc_table['index', 'cmdID', 'reflabel', 'output_name', 'steps_to_run', 'repeat_of_index_number', 'index_contained_within'])
+        print(mmm.proc_table['index', 'cmdID', 'reflabel', 'steps_to_run', 'repeat_of_index_number', 'index_contained_within'])
         #print(mmm.proc_table['strun_command'][-1])
-        #sys.exit()
+        sys.exit()
 
         self.ssbcmdtable = astrotableclass()
         self.ssbcmdtable.t = mmm.proc_table
@@ -912,7 +912,7 @@ class mkrefsclass(astrotableclass):
         # strun commands need to be executed, secondary strun commands
         # are already covered by primary strun commands
         self.check_if_primary_strun()
-        
+
         # check if the reduced input files exist or not, and fill
         # 'file_exists' column with True or False
         self.check_if_inputfiles_exists()
@@ -934,7 +934,7 @@ class mkrefsclass(astrotableclass):
 
         if self.verbose>1:
             print(self.ssbcmdtable.t['index','real_input_file','repeat_of_index_number', 'index_contained_within','primary_strun','file_exists','already_in_batch','execute_strun','strun_executed'])
-        
+
         #print('strun commands:')
         #print(mmm.strun)
 
@@ -948,12 +948,12 @@ class mkrefsclass(astrotableclass):
         if suffix != '.fits':
             print('WARNING: It seems like the filename {} is not a fits file.'.format(filename))
         return(outlog,errorlog)
-        
+
     def run_ssb_cmds(self,batchmode=False,ssblogFlag=False,ssberrorlogFlag=True):
         if self.onlyshow:
             if self.verbose: print('\n*** ONLYSHOW: skipping running the strun commands!\n')
             return(0)
-        
+
         # cleaning up old output files:
         for i in range(len(self.ssbcmdtable.t)):
             if self.ssbcmdtable.t['execute_strun'][i]:
@@ -967,7 +967,7 @@ class mkrefsclass(astrotableclass):
 
         if batchmode:
             print("### run strun commands in batch mode: NOT YET IMPLEMENTED!!!")
-            
+
             # submit the batch here, return errorflag in case there is an issue submitting the batch
             errorflag = 0
             strun_list = self.ssbcmdtable.t['strun_command'][indeces2run]
@@ -980,7 +980,7 @@ class mkrefsclass(astrotableclass):
                 self.ssbcmdtable.t['execute_strun'][indeces2run]='batch'
 
         else:
-            t4strun = self.ssbcmdtable.t[indeces2run] 
+            t4strun = self.ssbcmdtable.t[indeces2run]
             print(t4strun['index','execute_strun'])
             for i in range(len(t4strun)):
                 strun_cmd = t4strun['strun_command'][i]
@@ -990,7 +990,7 @@ class mkrefsclass(astrotableclass):
                 (logfilename,errlogfilename) = self.getlogfilenames(outfile)
                 if not self.cfg.params['output']['ssblogFlag']: logfilename=None
                 if not self.cfg.params['output']['ssberrorlogFlag']: errlogfilename=None
-                
+
                 print('### Executing strun command for index %d: %s' % (indeces2run[0][i],strun_cmd))
                 (errorflag) = executecommand(strun_cmd, '', cmdlog=logfilename, errorlog=errlogfilename)
 
@@ -1004,7 +1004,7 @@ class mkrefsclass(astrotableclass):
                     self.ssbcmdtable.t['strun_executed'][indeces2run[0][i]]='ERROR{}_serial'.format(errorflag)
                 else:
                     self.ssbcmdtable.t['strun_executed'][indeces2run[0][i]]='serial'
-                        
+
         if self.verbose>1:
             print(self.ssbcmdtable.t['index','real_input_file','repeat_of_index_number', 'index_contained_within','primary_strun','file_exists','already_in_batch','execute_strun','strun_executed'])
 
@@ -1045,7 +1045,7 @@ if __name__ == '__main__':
     #print('BBB',stdoutlist)
     #print('NNN',stderrlist)
     #sys.exit(0)
-    
+
     mkrefs = mkrefsclass()
     parser = mkrefs.define_options()
     args = parser.parse_args()

--- a/jwst_reffiles/pipeline/calib_prep.py
+++ b/jwst_reffiles/pipeline/calib_prep.py
@@ -133,8 +133,16 @@ class CalibPrep:
 
         # Change the entries in the 'index_contained_within' to be lists, for easy
         # indexing later.
-        new_contained_data = [list(entry) for entry in self.inputs['index_contained_within']]
+        new_contained_data = [sorted(list(entry)) for entry in self.inputs['index_contained_within']]
+
+        # To ensure that each entry in the Column is a list (rather than a scalar)
+        # add a dummy value that is a 2-element list.
+        new_contained_data.append([-42, -43])
         new_contained_column = Column(new_contained_data, name='index_contained_within')
+
+        # Now remove dummy value
+        new_contained_column = new_contained_column[0:-1]
+
         self.inputs.remove_column('index_contained_within')
         self.inputs.add_column(new_contained_column)
 
@@ -146,7 +154,16 @@ class CalibPrep:
 
         # Convert to a list so we can find unique elements
         repeats_list = [sorted(list(s)) for s in repeats]
+
+        # It seems that when all elements of repeats_list are one element lists,
+        #np.unique returns a list, whereas if some of the lists within repeat_list
+        #are multiple-element lists, then np.unique returns a list of lists. Try adding
+        # this dummy entry to force unique to always return a list of lists
+        repeats_list.append([-42, -42])
         unique_repeats = np.unique(repeats_list)
+
+        # Now pop the dummy entry out of unique_repeats
+        unique_repeats = unique_repeats[1:]
 
         for repeat_values in unique_repeats:
             # Set the first instance of the repeated group to -1 so it will be run.
@@ -155,8 +172,13 @@ class CalibPrep:
 
         # Change the entries in the 'repeat_of_index_number' to be lists, for easy
         # indexing later.
-        new_repeat_data = [list(entry) for entry in self.inputs['repeat_of_index_number']]
+        new_repeat_data = [sorted(list(entry)) for entry in self.inputs['repeat_of_index_number']]
+
+        # Repeat the dummy value trick here so that the column will contain lists
+        new_repeat_data.append([-42, -42])
         new_repeat_column = Column(new_repeat_data, name='repeat_of_index_number')
+        new_repeat_column = new_repeat_column[0:-1]
+
         self.inputs.remove_column('repeat_of_index_number')
         self.inputs.add_column(new_repeat_column)
 
@@ -502,7 +524,6 @@ class CalibPrep:
         files : list
             List of found files containing the input base string
         '''
-
         files = []
         for dirpath, dirnames, fnames in generator_object:
             mch = [f for f in fnames if base in os.path.join(dirpath, f) and f[-4:] == 'fits']

--- a/jwst_reffiles/pipeline/calwebb_detector1.cfg
+++ b/jwst_reffiles/pipeline/calwebb_detector1.cfg
@@ -1,0 +1,35 @@
+name = "Detector1Pipeline"
+class = "jwst.pipeline.Detector1Pipeline"
+save_calibrated_ramp = False
+
+    [steps]
+      [[group_scale]]
+        config_file = group_scale.cfg
+      [[dq_init]]
+        config_file = dq_init.cfg
+      [[saturation]]
+        config_file = saturation.cfg
+      [[ipc]]
+        skip = True
+      [[superbias]]
+        config_file = superbias.cfg
+      [[refpix]]
+        config_file = refpix.cfg
+      [[rscd]]
+        config_file = rscd.cfg
+      [[firstframe]]
+        config_file = firstframe.cfg
+      [[lastframe]]
+        config_file = lastframe.cfg
+      [[linearity]]
+        config_file = linearity.cfg
+      [[dark_current]]
+        config_file = dark_current.cfg
+      [[persistence]]
+        config_file = persistence.cfg
+      [[jump]]
+        config_file = jump.cfg
+      [[ramp_fit]]
+        config_file = ramp_fit.cfg
+      [[gain_scale]]
+        config_file = gain_scale.cfg


### PR DESCRIPTION
This PR introduces code to fix a few small bugs in `calib_prep`. 

Output table entries for repeats and "contained within" are now always lists, and always sorted into increasing order.

When searching for files previously run through the pipeline, non-fits files are ignored.

A calwebb_detector1 configuration file has been added to the repo. 

The code now also checks that the calwebb_detector1 pipeline configuration file is present in self.output_directory. If the config file is not present in self.output_directory, then the file from the repo is copied there.