### PR TITLE
ref commands working

### DIFF
--- a/jwst_reffiles/example/myexamplescript.py
+++ b/jwst_reffiles/example/myexamplescript.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+'''
+example script that is loaded by mkref_example_bpm.py
+A. Rest
+'''
+
+import numpy as np
+from jwst.datamodels import MaskModel
+
+# convenience function
+def make_maskmodel(ysize, xsize):
+
+    # create a mask model for the dq_init step
+    dq = np.zeros((ysize, xsize), dtype=int)
+
+    # define a dq_def extension
+    mask = MaskModel()
+
+    dqdef = [(0, 1, 'DO_NOT_USE', 'Bad Pixel do not use'),
+             (1, 2, 'DEAD', 'Dead Pixel'),
+             (2, 4, 'HOT', 'Hot pixel'),
+             (3, 8, 'UNRELIABLE_SLOPE', 'Large slope variance'),
+             (4, 16, 'RC', 'RC pixel'),
+             (5, 32, 'REFERENCE_PIXEL', 'Reference Pixel')]
+
+    dq_def = np.array((dqdef), dtype=mask.dq_def.dtype)
+
+    return dq, dq_def
+
+class example_mkbpmclass:
+    
+    def mkbpm(self,dark1filename,dark2filename,flat1filename,flat2filename,
+              whateveroption1=False,whateveroption2=2.0):
+
+        print('HELLO mkbpm in myexamplescript.py!!!')
+
+        # create an empty MaskModel for the bad pixel mask
+        xstart = 1
+        ystart = 1
+        xsize = 2048
+        ysize = 2048
+        
+        dq, dq_def = make_maskmodel(ysize, xsize)
+        
+        # write mask model and fix the meta data
+        mask_model = MaskModel(dq=dq, dq_def=dq_def)
+
+        return(mask_model)
+        

--- a/jwst_reffiles/mkref_bpm.py
+++ b/jwst_reffiles/mkref_bpm.py
@@ -22,7 +22,7 @@ class mkrefclassX(mkrefclass):
         return(0)
         
     def extraoptions(self, parser):
-        parser.add_argument('-x','--dummy_bpm_option1',
+        parser.add_argument('-x','--dummy_bpm_option1',nargs=2,
                             help='testoption1 bpm')
         return(0)
 

--- a/jwst_reffiles/mkref_bpm.py
+++ b/jwst_reffiles/mkref_bpm.py
@@ -6,32 +6,24 @@ A. Rest
 
 import argparse,os,re,sys,types
 
-from mkref_template import mkrefclass
+from mkref_template import mkrefclass_template
 
 from jwst_reffiles.utils.tools import astrotableclass,yamlcfgclass
 
-class mkrefclassX(mkrefclass):
+class mkrefclass(mkrefclass_template):
     def __init__(self,*args, **kwargs):
-        mkrefclass.__init__(self,*args, **kwargs)
+        mkrefclass_template.__init__(self,*args, **kwargs)
         self.reflabel='bpm'
         self.reftype='bpm'
 
-    def inputfileoptions(self, parser):
-        parser.add_argument('--D1',
-                            help='specify the dark exposure (default=%(default)s)')
-        return(0)
-        
-    def extraoptions(self, parser):
+    def extra_optional_arguments(self, parser):
         parser.add_argument('-x','--dummy_bpm_option1',nargs=2,
                             help='testoption1 bpm')
         return(0)
 
 
 if __name__ == '__main__':
-    print('bbb',sys.argv)
-    mkref = mkrefclassX()
-    (parser) = mkref.refoptions()
+    mkref = mkrefclass()
+    parser = mkref.allargs()
     args = parser.parse_args()
-    print('bbb',args)
-    sys.exit(0)
-    #mkref.mkref(sys.argv[1:])
+    mkref.callagorithm(args)

--- a/jwst_reffiles/mkref_example_bpm.py
+++ b/jwst_reffiles/mkref_example_bpm.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+'''
+example bpm script
+A. Rest
+'''
+
+import argparse,os,re,sys,types
+
+from mkref_template import mkrefclass_template
+
+# import your script!
+from jwst_reffiles.example.myexamplescript import example_mkbpmclass
+
+class mkrefclass(mkrefclass_template):
+    def __init__(self,*args, **kwargs):
+        mkrefclass_template.__init__(self,*args, **kwargs)
+
+        # You need to set this correctly
+        self.reflabel='example_bpm'
+        self.reftype='bpm'
+
+    def extra_optional_arguments(self, parser):
+        # you can add whatever optional arguments here!
+        parser.add_argument('--dummy_example_option1',nargs=2,
+                            help='testoption1 example bpm')
+        return(0)
+
+    def callalgorithm(self):
+        # call your algorithm. The only requirement is that the output reference file is saved as self.args.outputreffilename
+
+        print('*** This is the output filename of the reference file: {}'.format(self.args.outputreffilename))
+        print('*** This is the file with the list of the input images: {}'.format(self.args.imageslist_filename))
+        print('*** The table in this file got loaded into self.inputimages')
+
+        print('*** These are the filenames of the input images, and some more info:')
+        for i in range(len(self.inputimages)):
+            print('image {} has the type {} and taken at MJD={}'.format(self.inputimages['output_name'][i],
+                                                                        self.inputimages['imtype'][i],
+                                                                        self.inputimages['MJD'][i]))
+            
+        print('*** The config file is also loaded. This is how you can access it. There can be a section for each reflabel.')
+        print('*** section {}, parameter {}: {}'.format(self.reflabel,'random_option',self.cfg.params[self.reflabel]['random_option']))
+
+        print('*** You can use all this info to call whatever algorithm you like to apply!')
+        myscript = example_mkbpmclass()
+        mymask = myscript.mkbpm(self.inputimages['output_name'][0],self.inputimages['output_name'][1],
+                                self.inputimages['output_name'][0],self.inputimages['output_name'][1],
+                                whateveroption1=True,whateveroption2=self.cfg.params[self.reflabel]['random_option'])
+        
+        print('*** Now save it to the output reference filename {}'.format(self.args.outputreffilename))
+        mymask.save(self.args.outputreffilename)
+
+        return(0)
+
+if __name__ == '__main__':
+    mkref = mkrefclass()
+    mkref.make_reference_file()

--- a/jwst_reffiles/mkref_gain_armin.py
+++ b/jwst_reffiles/mkref_gain_armin.py
@@ -6,28 +6,17 @@ A. Rest
 
 import argparse,os,re,sys,types
 
-from mkref_template import mkrefclass
+from mkref_template import mkrefclass_template
 
 from jwst_reffiles.utils.tools import astrotableclass,yamlcfgclass
 
-class mkrefclassX(mkrefclass):
+class mkrefclass(mkrefclass_template):
     def __init__(self,*args, **kwargs):
-        mkrefclass.__init__(self,*args, **kwargs)
+        mkrefclass_template.__init__(self,*args, **kwargs)
         self.reflabel='gain_armin'
         self.reftype='gain'
-        
-    def inputfileoptions(self, parser):
-        parser.add_argument('--D1',required=True,
-                            help='specify the first dark exposure (default=%(default)s)')
-        parser.add_argument('--D2',required=True,
-                            help='specify the second dark exposure (default=%(default)s)')
-        parser.add_argument('--F1',required=True,
-                            help='specify the first flat exposure (default=%(default)s)')
-        parser.add_argument('--F2',required=True,
-                            help='specify the second flat exposure (default=%(default)s)')
-        return(0)
-        
-    def extraoptions(self, parser):
+                
+    def extra_optional_arguments(self, parser):
         parser.add_argument('-d', '--dummy_gain_option1', default=None, nargs=2,
                             help='testoption1 gainarmin')
         parser.add_argument('--dummy_gain_option2', default=None,
@@ -40,7 +29,7 @@ class mkrefclassX(mkrefclass):
         #myscript.myroutine(args.D1,args.F1,newgain=args.dummy_gain_option1)
     
 if __name__ == '__main__':
-    mkref = mkrefclassX()
-    (parser) = mkref.refoptions()
+    mkref = mkrefclass()
+    parser = mkref.allargs()
     args = parser.parse_args()
     mkref.callagorithm(args)

--- a/jwst_reffiles/mkref_gain_armin.py
+++ b/jwst_reffiles/mkref_gain_armin.py
@@ -28,9 +28,9 @@ class mkrefclassX(mkrefclass):
         return(0)
         
     def extraoptions(self, parser):
-        parser.add_argument('-d', '--dummy_gain_option1',
+        parser.add_argument('-d', '--dummy_gain_option1', default=None, nargs=2,
                             help='testoption1 gainarmin')
-        parser.add_argument('--dummy_gain_option2',
+        parser.add_argument('--dummy_gain_option2', default=None,
                             help='testoption2 gainarmin')
         return(0)
 

--- a/jwst_reffiles/mkref_rdnoise_nircam.py
+++ b/jwst_reffiles/mkref_rdnoise_nircam.py
@@ -13,7 +13,7 @@ from jwst_reffiles.utils.tools import astrotableclass,yamlcfgclass
 class mkrefclass(mkrefclass_template):
     def __init__(self,*args, **kwargs):
         mkrefclass_template.__init__(self,*args, **kwargs)
-        self.reflabel='rdnoisenircam'
+        self.reflabel='rdnoise_nircam'
         self.reftype='rdnoise'
 
     def extra_optional_arguments(self, parser):

--- a/jwst_reffiles/mkref_rdnoise_nircam.py
+++ b/jwst_reffiles/mkref_rdnoise_nircam.py
@@ -6,22 +6,17 @@ A. Rest
 
 import argparse,os,re,sys,types
 
-from mkref_template import mkrefclass
+from mkref_template import mkrefclass_template
 
 from jwst_reffiles.utils.tools import astrotableclass,yamlcfgclass
 
-class mkrefclassX(mkrefclass):
+class mkrefclass(mkrefclass_template):
     def __init__(self,*args, **kwargs):
-        mkrefclass.__init__(self,*args, **kwargs)
+        mkrefclass_template.__init__(self,*args, **kwargs)
         self.reflabel='rdnoisenircam'
         self.reftype='rdnoise'
 
-    def inputfileoptions(self, parser):
-        parser.add_argument('--D1',
-                            help='specify the dark exposure (default=%(default)s)')
-        return(0)
-        
-    def extraoptions(self, parser):
+    def extra_optional_arguments(self, parser):
         parser.add_argument('-x','--dummy_rdnoise_option1',
                             help='testoption1 readnoise')
         parser.add_argument('--dummy_rdnoise_option2',
@@ -30,10 +25,7 @@ class mkrefclassX(mkrefclass):
 
 
 if __name__ == '__main__':
-    print('bbb',sys.argv)
-    mkref = mkrefclassX()
-    (parser) = mkref.refoptions()
+    mkref = mkrefclass()
+    parser = mkref.allargs()
     args = parser.parse_args()
-    print('bbb',args)
-    sys.exit(0)
-    #mkref.mkref(sys.argv[1:])
+    mkref.callagorithm(args)

--- a/jwst_reffiles/mkref_template.py
+++ b/jwst_reffiles/mkref_template.py
@@ -25,9 +25,10 @@ class mkrefclass:
 
         self.inputfiles = None
 
-    def defaultoptions(self, parser=None, usage=None, conflict_handler=None):
+    def default_optional_arguments(self, parser=None, usage=None, conflict_handler=None):
         if parser is None:
             parser = argparse.ArgumentParser(usage=usage, conflict_handler=conflict_handler)
+
         parser.add_argument('--verbose', '-v', action='count')
         parser.add_argument('-d', '--debug', help="debug", action='count')
 
@@ -53,23 +54,27 @@ class mkrefclass:
 
         return parser
 
-    def inputfileoptions(self, parser):
-        """ add here the input file options --D?, --F?, --S? """
-        print("PLACEHOLDER for input file options")
+    def positional_arguments(self, parser):
+        """ 
+        The filename of the output reference file is the first argument.
+        The filename of the input image list is the second argument
+        """
+        parser.add_argument("outputreffilename", nargs=1, help=("The filename of the output reference file"))
+        parser.add_argument("imageslist_filename", nargs=1, help=("The filename of the input image list"))
         return(0)
 
-    def extraoptions(self, parser, only_optional_arguments=False):
+    def extra_optional_arguments(self, parser, only_optional_arguments=False):
         """ add here the extra options for a given reference file maker """
         print("PLACEHOLDER for extraoptions")
         return(0)
 
-    def alloptions(self, reftype=None, parser=None, subparsers=None, subparserlist=None, usage=None):
+    def allargs(self,  parser=None, subparsers=None, subparserlist=None, usage=None):
         if parser is None:
             parser = argparse.ArgumentParser(usage=usage, conflict_handler='resolve')
 
-        self.defaultoptions(parser=parser, usage=None)
+        self.default_optional_arguments(parser=parser)
 
-        self.extraoptions(parser)
+        self.extra_optional_arguments(parser)
         self.inputfileoptions(parser)
 
         return(parser)

--- a/jwst_reffiles/mkrefs.cfg
+++ b/jwst_reffiles/mkrefs.cfg
@@ -65,7 +65,7 @@ batch:
 
 
 test1: 4
-
+test2: 5
 # values allowed: CRDS, SELF, filepattern
 reffile4ssb:
    gain: CRDS

--- a/jwst_reffiles/mkrefs.cfg
+++ b/jwst_reffiles/mkrefs.cfg
@@ -1,5 +1,5 @@
 instrument: NIRCam
-reflabels: [gain_armin,bpm,rdnoise_nircam]
+reflabels: [example_bpm,gain_armin,bpm,rdnoise_nircam]
 reftypes: [bpm,rdnoise,gain,linearity]
 
 default_reflabels:
@@ -63,25 +63,42 @@ batch:
    batch_enabled: False
    batchmode: Condor
 
-
 test1: 4
 test2: 5
+
 # values allowed: CRDS, SELF, filepattern
 reffile4ssb:
    gain: CRDS
    bpm: CRDS
    rdnoise: CRDS
 
+# after a reference file is created, run the following tests:
+# (1) load it into the appropriate data model
+# (2) run it through ssb
+test4datamodel: False
+test4ssb: True
+
 # values allowed: CRDS, filename
 validation:
    gainreffile: CRDS
    bpmreffile: CRDS
 
+example_bpm:
+    reftype: bpm
+    imtypes: DDFF
+    ssbsteps: refpix-
+    # after a reference file is created, run the following tests:
+    # (1) load it into the appropriate data model
+    # (2) run it through ssb
+    test4datamodel: True
+    test4ssb: True
+    # add any random paramters
+    random_option: hello
+
 bpm:
     reftype: bpm
     imtypes: D
     ssbsteps: refpix-
-
 
 rdnoise_nircam:
     reftype: rdnoise

--- a/jwst_reffiles/utils/tools.py
+++ b/jwst_reffiles/utils/tools.py
@@ -518,7 +518,7 @@ class astrotableclass:
                 else:
                     print('WARNING! col %s does not exist, so cannot format it!' % name)
 
-    def write(self, filename, clobber=True, verbose=False, format='commented_header',
+    def write(self, filename, indeces=None, clobber=True, verbose=False, format='commented_header',
               makepathFlag=True, **kwargs):
         if verbose:
             print('Saving %s' % filename)
@@ -535,9 +535,15 @@ class astrotableclass:
             if os.path.isfile(filename):
                 print('ERROR: could not save %s' % filename)
                 return(2)
+            
+        if indeces is None:
+            ascii.write(self.t, filename, format=format, **kwargs)
+        else:
+            ascii.write(self.t[indeces], filename, format=format, **kwargs)
 
-        ascii.write(self.t, filename, format=format, **kwargs)
-
+        return(0)
+    
+            
     def fitsheader2table(self, fitsfilecolname, rowindices=None, requiredfitskeys=None,
                          optionalfitskey=None, raiseError=True, skipcolname=None, headercol=None):
         if rowindices is None:

--- a/jwst_reffiles/utils/tools.py
+++ b/jwst_reffiles/utils/tools.py
@@ -456,16 +456,14 @@ class yamlcfgclass:
 
         # read in the additional config files
         if extracfgfiles is not None:
-            if type(extracfgfiles) is bytes:
+            if isinstance(extracfgfiles,str):
                 self.addcfgfile(extracfgfiles, requireParamExists=requireParamExists, verbose=verbose)
-            elif type(extracfgfiles) is list:
+            elif isinstance(extracfgfiles,list):
                 for filename in extracfgfiles:
                     self.addcfgfile(filename, requireParamExists=requireParamExists, verbose=verbose)
             else:
-                if raiseErrorFlag:
-                    print('ERROR: this is the extra cfg filelist:', extracfgfiles)
-                    raise RuntimeError("ERROR: Don't know what to do with this filelist!!")
-                return(1)
+                print('ERROR: this is the extra cfg filelist:', extracfgfiles)
+                raise RuntimeError("ERROR: Don't know what to do with this filelist!!")
 
         # change the configs based on -p and --pp options
         self.setvals(params, requireParamExists=requireParamExists)


### PR DESCRIPTION
A lot of progress over the holidays

- I populated the new class cmdsclass with all the infrastructure to run the commands (batch or seriel), and test if the output files exists. This streamlines creating and executing commands for ssb, ref commands, and refmaster commands.
- check out mkref_example_bpm.py, which is a child of mkref_template.py. This is how new scripts can be added.
- After teh few small things in the ssb reduction are fixed, we are ready to add algorithms!

If you are around tomorrow, let's get together and I show you some of the details!
