### PR TITLE
Install JWST directly from github

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx>=1.4
 ipykernel
 nbsphinx
-jwst>=0.12.2
+git+https://github.com/spacetelescope/jwst.git@master


### PR DESCRIPTION
Readthedocs build failed when simply specifying `jwst` in `requirements.txt`. I've updated so that the `jwst` package is installed directly from github.