### PR TITLE
Specify minimum numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy
+numpy>=1.13
 sphinx>=1.4
 ipykernel
 nbsphinx


### PR DESCRIPTION
Still playing with the `requirements.txt` file to get readthedocs to build the documentation correctly.