### PR TITLE
Switch to stable branch of jwst in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ numpy>=1.13
 sphinx>=1.4
 ipykernel
 nbsphinx
-git+https://github.com/spacetelescope/jwst.git@master
+git+https://github.com/spacetelescope/jwst.git@mstable


### PR DESCRIPTION
More readthedocs build trouble. Switching to the `stable` branch of the `jwst` package to see if that helps. Previous build failure occurred while trying to install `jwst`.