### PR TITLE
Add logging

### DIFF
--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -1280,6 +1280,11 @@ if __name__ == '__main__':
                     runID=args.runID, runIDNdigits=args.runIDNdigits, newrunID=args.newrunID,
                     ssbdir=args.ssbdir, skip_runID_ssbdir=args.skip_runID_ssbdir)
 
+    # Set up logging
+    configure_logging("jwst_reffiles", path=self.output_dir)
+    print("This needs to move higher up so that we can log all of the config file stuff")
+    print("But we need the output directory for the log file before we can configure logging")
+
     # get the inputfile list and reflabel list. For input files, get into!
     mkrefs.organize_inputfiles(args.reflabels_and_imagelist)
 

--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -42,7 +42,6 @@ class cmdsclass(astrotableclass):
         else:
             self.manual_log = None
             self.logger = logging.getLogger('jwst_reffiles.mkrefs.cmdsclass')
-            self.logger.warning("This is a cmdclass test using the logger")
         astrotableclass.__init__(self, *args, **kwargs)
         self.verbose=verbose
         self.debug=debug
@@ -173,7 +172,7 @@ class cmdsclass(astrotableclass):
             outlog = None
 
         if suffix != '.fits':
-            self.create_log_entry('error', 'WARNING: It seems like the filename {} is not a fits file.'.format(filename))
+            self.create_log_entry('warning', 'It seems like the filename {} is not a fits file.'.format(filename))
             #self.logger.error('WARNING: It seems like the filename {} is not a fits file.'.format(filename))
 
         return(outlog, errorlog)
@@ -185,7 +184,7 @@ class cmdsclass(astrotableclass):
 
         for outfile in outputfiles:
             outfile = self.filename_with_suffix(outfile,addsuffix=addsuffix)
-            (logfilename,errlogfilename) = self.getlogfilenames(outfile, logFlag=True, errorlogFlag=True)
+            (logfilename, errlogfilename) = self.getlogfilenames(outfile, logFlag=True, errorlogFlag=True)
             rmfile(outfile)
             rmfile(logfilename)
             # Don't clean up errlogfilename, we want to keep track of old errors...
@@ -195,7 +194,7 @@ class cmdsclass(astrotableclass):
         """ dummy call to batch mode to return reasonable values """
         print("### run commands in batch mode: NOT YET IMPLEMENTED!!!")
         # this are just dummy return values until batch mode is implemented
-        (errorflag, batchID)=(1,random.randint(1, 100000))
+        (errorflag, batchID) = (1, random.randint(1, 100000))
 
         return(errorflag, batchID)
 
@@ -218,7 +217,7 @@ class cmdsclass(astrotableclass):
         self.create_log_entry('info', 'Saving cmds to {} for batch'.format(batchfilename))
         #self.logger.info('Saving cmds to {} for batch'.format(batchfilename))
         strun_list = [l+'\n' for l in strun_list]
-        if open(batchfilename,'w').writelines(strun_list):
+        if open(batchfilename, 'w').writelines(strun_list):
             self.create_log_entry('error', 'ERROR: could not save batch file {}'.format(batchfilename))
             raise RuntimeError('ERROR: could not save batch file {}'.format(batchfilename))
 
@@ -279,14 +278,15 @@ class cmdsclass(astrotableclass):
 
             # extra error checking
             if not os.path.isfile(outfile):
-                self.create_log_entry('warning', 'ERROR: file {} did not get created with strun command!'.format(outfile))
+                self.create_log_entry('warning', 'File {} did not get created with strun command!'.format(outfile))
                 #self.logger.warning('ERROR: file {} did not get created with strun command!'.format(outfile))
                 errorflag |= 2
 
             # fill table with results.
             if errorflag:
                 self.t[cmds_executed_col][i]='ERROR{}_serial'.format(errorflag)
-                self.create_log_entry('warning', "Error Flag: {}. There was an error running this command.".format(errorflag))
+                self.create_log_entry('warning', ("In run_cms_serial, Error Flag: {}. There was an error "
+                                                  "running this command.".format(errorflag)))
                 #self.logger.warning("Error Flag: {}. There was an error running this command.".format(errorflag))
             else:
                 self.create_log_entry('info', "Error Flag: 0. Command completed successfully.")
@@ -346,10 +346,6 @@ class mkrefsclass(astrotableclass):
 
         self.loginfo.append(('info', 'Allowed reflabels are {}'.format(self.allowed_reflabels)))
         self.loginfo.append(('info', 'Reflabel directories are {}'.format(self.reflabel_directories)))
-
-        #self.logger = logging.getLogger('jwst_reffiles.mkrefs.mkrefclass')
-        #self.logger.warning("This is a mkrefs class test")
-        self.loginfo.append(("info", "This is a mkrefs class test"))
 
     def define_options(self, parser=None, usage=None, conflict_handler='resolve'):
         if parser is None:

--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -36,7 +36,7 @@ from jwst_reffiles.utils.tools import makepath, executecommand, append2file, rmf
 class cmdsclass(astrotableclass):
     def __init__(self, cmdtype, *args, verbose=0, debug=False, **kwargs):
         #self.loginfo.append(('info', "Creating cmdsclass instance with cmdtype {}".format(cmdtype)))
-        self.logger = logging.getLogger('mkrefs.cmdsclass')
+        self.logger = logging.getLogger('jwst_reffiles.mkrefs.cmdsclass')
         self.logger.warning("This is a cmdclass test")
         astrotableclass.__init__(self, *args, **kwargs)
         self.verbose=verbose
@@ -300,9 +300,8 @@ class mkrefsclass(astrotableclass):
         self.mkref_file_list = copy.deepcopy(mkref_file_list)
         self.loginfo = []
 
-        self.logger = logging.getLogger('mkrefs.mkrefclass')
+        self.logger = logging.getLogger('jwst_reffiles.mkrefs.mkrefclass')
         self.logger.warning("This is a mkrefs class test")
-
 
     def define_options(self, parser=None, usage=None, conflict_handler='resolve'):
         if parser is None:
@@ -1324,14 +1323,18 @@ if __name__ == '__main__':
     # Set up logging
     #configure_logging("jwst_reffiles", path=mkrefs.basename)
 
-
+    main_log_file = configure_logging("mkrefs", path=mkrefs.basedir)
+    print("LOG FILE: {}".format(main_log_file))
+    """
     ########If this works, put into its own funtionc######
     # Create the Logger
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO)
 
     # Create the Handler for logging data to a file
-    logger_handler = RotatingFileHandler('log.log')  # , maxBytes=1024, backupCount=5)
+    logfilename = os.path.join(mkrefs.basedir, 'mkrefs_run.log')
+    print('Log file to be created: {}'.format(logfilename))
+    logger_handler = RotatingFileHandler(logfilename)  # , maxBytes=1024, backupCount=5)
     logger_handler.setLevel(logging.INFO)
 
     # Create the Handler for logging data to console.
@@ -1349,7 +1352,7 @@ if __name__ == '__main__':
     # Add the Handler to the Logger
     root_logger.addHandler(logger_handler)
     root_logger.addHandler(console_handler)
-
+    """
 
 
 

--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -479,7 +479,7 @@ class mkrefsclass(astrotableclass):
         """ find all subdirs witn run\d+ within the passed basedir, and extract the highest runID"""
         files = glob.glob('%s/run*' % basedir)
         if len(files) == 0:
-            self.logger.info('In get_highest_runID: No runIDs yet!')
+            self.loginfo.append(('info', 'In get_highest_runID: No runIDs yet!'))
             return(None)
         runIDs = []
         runIDpattern = re.compile('run(\d+)$')

--- a/jwst_reffiles/pipeline/calib_prep.py
+++ b/jwst_reffiles/pipeline/calib_prep.py
@@ -104,8 +104,8 @@ from jwst_reffiles.utils.logging_functions import configure_logging, log_info, l
 
 
 class CalibPrep:
-    def __init__(self):
-        self.logger = logging.getLogger('jwst_reffiles.pipeline.caib_prep.CalibPrep')
+    def __init__(self, instrument):
+        self.logger = logging.getLogger(__name__)
         self.logger.info('Creating an instance of CalibPrep')
         self.__version__ = 0.1
         self.verbose = True

--- a/jwst_reffiles/utils/logging_functions.py
+++ b/jwst_reffiles/utils/logging_functions.py
@@ -57,6 +57,8 @@ import datetime
 import getpass
 import importlib
 import logging
+from logging import StreamHandler
+from logging.handlers import RotatingFileHandler
 import os
 import pwd
 import socket
@@ -88,11 +90,39 @@ def configure_logging(module, path='./'):
     LOG_FILE_LOC = log_file
 
     # Create the log file and set the permissions
-    logging.basicConfig(filename=log_file,
-                        format='%(asctime)s %(levelname)s: %(message)s',
-                        datefmt='%m/%d/%Y %H:%M:%S %p',
-                        level=logging.INFO)
-    set_permissions(log_file)
+    #logging.basicConfig(filename=log_file,
+    #                    format='%(asctime)s %(levelname)s: %(message)s',
+    #                    datefmt='%m/%d/%Y %H:%M:%S %p',
+    #                    level=logging.INFO)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
+
+    # Create the Handler for logging data to a file
+    #logfilename = os.path.join(mkrefs.basedir, 'mkrefs_run.log')
+    #print('Log file to be created: {}'.format(logfilename))
+    logger_handler = RotatingFileHandler(log_file)  # , maxBytes=1024, backupCount=5)
+    logger_handler.setLevel(logging.INFO)
+
+    # Create the Handler for logging data to console.
+    console_handler = StreamHandler()
+    console_handler.setLevel(logging.INFO)
+
+    # Create a Formatter for formatting the log messages
+    logger_formatter = logging.Formatter('%(name)s - %(asctime)s - %(levelname)s - %(message)s',
+                                         datefmt='%m/%d/%Y %H:%M:%S %p')
+
+    # Add the Formatter to the Handler
+    logger_handler.setFormatter(logger_formatter)
+    console_handler.setFormatter(logger_formatter)
+
+    # Add the Handler to the Logger
+    root_logger.addHandler(logger_handler)
+    root_logger.addHandler(console_handler)
+
+    # Currently need to be on ST network for this to work??
+    # set_permissions(log_file, verbose=True)
+    return log_file
 
 
 def make_log_file(module, path='./'):

--- a/jwst_reffiles/utils/logging_functions.py
+++ b/jwst_reffiles/utils/logging_functions.py
@@ -66,8 +66,7 @@ import traceback
 
 from functools import wraps
 
-from jwql.permissions.permissions import set_permissions
-from jwql.utils.utils import get_config
+from jwst_reffiles.utils.permissions import set_permissions
 
 LOG_FILE_LOC = ''
 

--- a/jwst_reffiles/utils/logging_functions.py
+++ b/jwst_reffiles/utils/logging_functions.py
@@ -1,17 +1,15 @@
 
 """ Logging functions for the mkrefs
 
-This module provides decorators to log the execution of modules.  Log
-files are written to the ``logs/`` directory in the ``jwql`` central
-storage area, named by module name and timestamp, e.g.
-``monitor_filesystem/monitor_filesystem_2018-06-20-15:22:51.log``
-
+This module configures the logger for the jwst_reffiles package.
+It also provides decorators to log the execution of modules. This code is
+based on the JWQL package logging configuration code.
 
 Authors
 -------
 
     - Bryan Hilbert 2018
-    - Catherine Martlin 2018
+    - Catherine Martlin 2018 (JWQL version)
     - Alex Viana, 2013 (WFC3 QL Version)
 
 Use
@@ -39,13 +37,6 @@ Use
 
             my_main_function()
 
-Dependencies
-------------
-
-    The user must have a configuration file named ``config.json``
-    placed in the ``utils`` directory.
-
-
 References
 ----------
     This code is adopted and updated from python routine
@@ -58,9 +49,9 @@ import getpass
 import importlib
 import logging
 from logging import StreamHandler
+import logging.config
 from logging.handlers import RotatingFileHandler
 import os
-import pwd
 import socket
 import sys
 import time
@@ -70,46 +61,48 @@ from functools import wraps
 
 from jwst_reffiles.utils.permissions import set_permissions
 
-LOG_FILE_LOC = ''
 
-
-def configure_logging(module, path='./'):
+def configure_logging(module, path='./', log_file_level='info', log_screen_level="info"):
     """Configure the log file with a standard logging format.
 
     Parameters
     ----------
     module : str
         The name of the module being logged.
+
     path : str
         Where to write the log if user-supplied path; default to working dir.
+
+    log_file_level : str
+        Minimum message level to route to the output log file.
+        Allowed values: "debug", "info", "warning", "ciritical"
+
+    log_screen_level : str
+        Minimum message level to route to the screen.
+        Allowed values: "debug", "info", "warning", "ciritical"
+
+    Returns
+    -------
+    log_file : str
+        Name and path of the output log file
     """
 
     # Determine log file location
     log_file = make_log_file(module, path=path)
-    global LOG_FILE_LOC
-    LOG_FILE_LOC = log_file
-
-    # Create the log file and set the permissions
-    #logging.basicConfig(filename=log_file,
-    #                    format='%(asctime)s %(levelname)s: %(message)s',
-    #                    datefmt='%m/%d/%Y %H:%M:%S %p',
-    #                    level=logging.INFO)
 
     root_logger = logging.getLogger()
     root_logger.setLevel(logging.INFO)
 
     # Create the Handler for logging data to a file
-    #logfilename = os.path.join(mkrefs.basedir, 'mkrefs_run.log')
-    #print('Log file to be created: {}'.format(logfilename))
-    logger_handler = RotatingFileHandler(log_file)  # , maxBytes=1024, backupCount=5)
-    logger_handler.setLevel(logging.INFO)
+    logger_handler = RotatingFileHandler(log_file)
+    logger_handler.setLevel(log_file_level.upper())
 
     # Create the Handler for logging data to console.
     console_handler = StreamHandler()
-    console_handler.setLevel(logging.INFO)
+    console_handler.setLevel(log_screen_level.upper())
 
     # Create a Formatter for formatting the log messages
-    logger_formatter = logging.Formatter('%(name)s - %(asctime)s - %(levelname)s - %(message)s',
+    logger_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s',
                                          datefmt='%m/%d/%Y %H:%M:%S %p')
 
     # Add the Formatter to the Handler
@@ -121,7 +114,7 @@ def configure_logging(module, path='./'):
     root_logger.addHandler(console_handler)
 
     # Currently need to be on ST network for this to work??
-    # set_permissions(log_file, verbose=True)
+    set_permissions(log_file, verbose=False)
     return log_file
 
 
@@ -147,7 +140,6 @@ def make_log_file(module, path='./'):
 
     timestamp = datetime.datetime.now().strftime('%Y-%m-%d-%H-%M')
     filename = '{0}_{1}.log'.format(module, timestamp)
-    #user = pwd.getpwuid(os.getuid()).pw_name
     log_file = os.path.join(path, filename)
 
     return log_file

--- a/jwst_reffiles/utils/permissions.py
+++ b/jwst_reffiles/utils/permissions.py
@@ -155,6 +155,12 @@ def has_permissions(pathname, mode=DEFAULT_MODE, group=DEFAULT_GROUP):
     elif os.path.isdir(pathname):
         mode = mode | stat.S_IFDIR
 
+    print('%%%%%%%%%%%%%%%%%%%%')
+    print(mode)
+    print(group)
+    print(file_statinfo)
+    print(groupinfo)
+
     if (file_statinfo.st_mode != mode) or (groupinfo.gr_name != group):
         return False
 

--- a/jwst_reffiles/utils/permissions.py
+++ b/jwst_reffiles/utils/permissions.py
@@ -20,7 +20,7 @@ Use
 
     ::
 
-        from nircam_calib.tools import permissions
+        from jwst_reffiles.utils import permissions
         permissions.set_permissions(pathname)
 
     Required arguments:
@@ -81,7 +81,7 @@ import pwd
 import stat
 
 # owner and group names to use
-DEFAULT_GROUP = 'STSCI/science'
+DEFAULT_GROUP = 'staff'
 
 # set the default mode for DEFAULT_OWNER
 DEFAULT_MODE = stat.S_IREAD | stat.S_IWRITE | stat.S_IRGRP | stat.S_IWGRP  # '?rw-rw----'
@@ -125,7 +125,7 @@ def get_owner_string(pathname):
     return owner_name
 
 
-def has_permissions(pathname, mode=DEFAULT_MODE, group=DEFAULT_GROUP):
+def has_permissions(pathname, mode=DEFAULT_MODE, group=DEFAULT_GROUP, verbose=False):
     """Return boolean indicating whether ``pathname`` has the specified
     owner, permission, and group scheme.
 
@@ -140,6 +140,8 @@ def has_permissions(pathname, mode=DEFAULT_MODE, group=DEFAULT_GROUP):
         with ``os.stat`` output
     group : str
         String representation of the group
+    verbose : bool
+        Boolean indicating whether verbose output is requested
 
     Returns
     -------
@@ -155,11 +157,12 @@ def has_permissions(pathname, mode=DEFAULT_MODE, group=DEFAULT_GROUP):
     elif os.path.isdir(pathname):
         mode = mode | stat.S_IFDIR
 
-    print('%%%%%%%%%%%%%%%%%%%%')
-    print(mode)
-    print(group)
-    print(file_statinfo)
-    print(groupinfo)
+    if verbose:
+        print('%%%%%%%%%%%%%%%%%%%%')
+        print(mode)
+        print(group)
+        print(file_statinfo)
+        print(groupinfo)
 
     if (file_statinfo.st_mode != mode) or (groupinfo.gr_name != group):
         return False

--- a/jwst_reffiles/utils/permissions.py
+++ b/jwst_reffiles/utils/permissions.py
@@ -84,7 +84,7 @@ import stat
 DEFAULT_GROUP = 'staff'
 
 # set the default mode for DEFAULT_OWNER - '?rw-rw-rw-'
-DEFAULT_MODE = stat.S_IREAD | stat.S_IWRITE | stat.S_IRGRP | stat.S_IWGRP | stat.IROTH | stat.IWOTH
+DEFAULT_MODE = stat.S_IREAD | stat.S_IWRITE | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH
 
 
 def get_group_string(pathname):

--- a/jwst_reffiles/utils/permissions.py
+++ b/jwst_reffiles/utils/permissions.py
@@ -83,8 +83,8 @@ import stat
 # owner and group names to use
 DEFAULT_GROUP = 'staff'
 
-# set the default mode for DEFAULT_OWNER - '?rw-rw-rw-'
-DEFAULT_MODE = stat.S_IREAD | stat.S_IWRITE | stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH
+# set the default mode for DEFAULT_OWNER - '?rw-r-----'
+DEFAULT_MODE = stat.S_IREAD | stat.S_IWRITE | stat.S_IRGRP
 
 
 def get_group_string(pathname):

--- a/jwst_reffiles/utils/permissions.py
+++ b/jwst_reffiles/utils/permissions.py
@@ -83,8 +83,8 @@ import stat
 # owner and group names to use
 DEFAULT_GROUP = 'staff'
 
-# set the default mode for DEFAULT_OWNER
-DEFAULT_MODE = stat.S_IREAD | stat.S_IWRITE | stat.S_IRGRP | stat.S_IWGRP  # '?rw-rw----'
+# set the default mode for DEFAULT_OWNER - '?rw-rw-rw-'
+DEFAULT_MODE = stat.S_IREAD | stat.S_IWRITE | stat.S_IRGRP | stat.S_IWGRP | stat.IROTH | stat.IWOTH
 
 
 def get_group_string(pathname):

--- a/jwst_reffiles/utils/permissions.py
+++ b/jwst_reffiles/utils/permissions.py
@@ -195,7 +195,7 @@ def set_permissions(pathname, mode=DEFAULT_MODE, group=DEFAULT_GROUP, verbose=Fa
     if not has_permissions(pathname):
         os.chmod(pathname, mode)
         # change group
-        os.chown(pathname, -1, grp.getgrnam(group).gr_gid)
+        # os.chown(pathname, -1, grp.getgrnam(group).gr_gid)
 
     if verbose:
         print('After:')


### PR DESCRIPTION
This PR introduces code to enable logging in the `jwst_reffiles` package. Currently logging covers only `mkrefs.py, mkref.py, and pipeline/calib_prep,.py`. Logging for modules that will be plugged in will be captured in different files. The names of these files are present in the log file created by these code changes.

I have added the minimum logging level for 1) the output log file and 2) messages to the screen, as user inputs. This way users can customize the logs without having to update the code itself. Both parameters default to using INFO as the minimum log level. Options are 'critical', 'warning', 'info',' and 'debug'. 

To set the levels:
`mkrefs.py -vvv --cfgfile mkrefs.cfg example_readnoise_module My_dir/darks/*DARK-600*level1b_Sept2018_uncal.fits My_dir/A1/F150W2/NRCN815A-LIN-53650[5678]*uncal.fits --logFileLevel info --logScreenLevel warning`

The output log file is written to a directory specified by the runID, and includes a timestamp in the filename, for uniqueness.