### PR TITLE
Add setuptools==40.8.0 to requirements 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools==40.8.0
 numpy>=1.13
 sphinx>=1.4
 ipykernel


### PR DESCRIPTION
This is an attempt to get around a readthedocs build failure that I think has something to do with an interaction between the latest version of pip and setuptools.

https://github.com/rtfd/readthedocs.org/issues/5436