### PR TITLE
Revert back to pip 18.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pip==18.1
 setuptools==40.8.0
 numpy>=1.13
 sphinx>=1.4


### PR DESCRIPTION
Another try at getting around the readthedocs build failure. Reverting back to pip 18.1, since from what I've read the problem comes from the interaction of pip 19.0 and setuptools.