### PR TITLE
Added hard cut defaults for absolute rate dead pixel search

### DIFF
--- a/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
+++ b/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
@@ -64,7 +64,6 @@ import os
 from astropy.convolution import convolve, Box2DKernel
 from astropy.io import fits
 from astropy.stats import sigma_clip
-from astropy.table import Table
 from jwst.datamodels import dqflags, util, MaskModel, Level1bModel
 from jwst.dq_init import DQInitStep
 

--- a/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
+++ b/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
@@ -225,8 +225,6 @@ def find_bad_pix(input_files, dead_search=True, low_qe_and_open_search=True, dea
         elif dead_search_type == 'absolute_rate':
             if max_dead_norm_signal == None:
                 max_dead_norm_signal = get_max_dead_norm_signal_default(instrument=instrument, detector=detector)
-
-            print(max_dead_norm_signal)
             dead_map = dead_pixels_absolute_rate(normalized, max_dead_signal=max_dead_norm_signal)
         dead_map = pad_with_refpix(dead_map, instrument)
 

--- a/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
+++ b/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
@@ -223,8 +223,10 @@ def find_bad_pix(input_files, dead_search=True, low_qe_and_open_search=True, dea
         elif dead_search_type == 'sigma_rate':
             dead_map = dead_pixels_sigma_rate(normalized, norm_mean, norm_dev, sigma=dead_sigma_threshold)
         elif dead_search_type == 'absolute_rate':
-            if max_dead_norm_signal == None:
-                max_dead_norm_signal = get_max_dead_norm_signal_default(instrument=instrument, detector=detector)
+            if max_dead_norm_signal is None:
+                max_dead_norm_signal = get_max_dead_norm_signal_default(instrument=instrument, 
+                                                                        detector=detector,
+                                                                        normalization_method=normalization_method.lower())
             dead_map = dead_pixels_absolute_rate(normalized, max_dead_signal=max_dead_norm_signal)
         dead_map = pad_with_refpix(dead_map, instrument)
 
@@ -728,7 +730,7 @@ def get_fastaxis(filename):
     return fastaxis, slowaxis
 
 
-def get_max_dead_norm_signal_default(instrument, detector):
+def get_max_dead_norm_signal_default(instrument, detector, normalization_method):
     """
     Finds the default max_dead_norm_signal value to use for the 
     absolute_rate dead pixel search type.
@@ -741,12 +743,22 @@ def get_max_dead_norm_signal_default(instrument, detector):
     detector : str
         The name of the detector
 
+    normalization_method : str
+        Specify how the mean image is normalized prior to searching for
+        bad pixels. Options are:
+        'smoothed': Mean image will be smoothed using a
+                    ``smoothing_box_width`` x ``smoothing_box_width``
+                    box kernel. The mean image is then normalized by
+                    this smoothed image.
+        'none': No normalization is done. Mean slope image is used as is
+        'mean': Mean image is normalized by its sigma-clipped mean
+
     Returns
     -------
     default_value : float
         The default max_dead_norm_signal value
     """
-    if instrument == 'NIRCAM':
+    if (instrument == 'NIRCAM') & (normalization_method == 'none'):
         detectors = ['NRCA1', 'NRCA2', 'NRCA3', 'NRCA4', 'NRCALONG', 
                      'NRCB1', 'NRCB2', 'NRCB3', 'NRCB4', 'NRCBLONG']
         defaults = [25.0, 25.0, 30.0, 30.0, 40.0, 

--- a/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
+++ b/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
@@ -64,13 +64,14 @@ import os
 from astropy.convolution import convolve, Box2DKernel
 from astropy.io import fits
 from astropy.stats import sigma_clip
+from astropy.table import Table
 from jwst.datamodels import dqflags, util, MaskModel, Level1bModel
 from jwst.dq_init import DQInitStep
 
 
 def find_bad_pix(input_files, dead_search=True, low_qe_and_open_search=True, dead_search_type='sigma_rate',
                  sigma_threshold=3, normalization_method='smoothed', smoothing_box_width=15,
-                 dead_sigma_threshold=5., dead_zero_signal_fraction=0.9, max_dead_norm_signal=0.05,
+                 dead_sigma_threshold=5., dead_zero_signal_fraction=0.9, max_dead_norm_signal=None,
                  max_low_qe_norm_signal=0.5, max_open_adj_norm_signal=1.05, do_not_use=[], output_file=None,
                  author='jwst_reffiles', description='A bad pix mask', pedigree='GROUND',
                  useafter='2019-04-01 00:00:00', history='', quality_check=True):
@@ -223,6 +224,10 @@ def find_bad_pix(input_files, dead_search=True, low_qe_and_open_search=True, dea
         elif dead_search_type == 'sigma_rate':
             dead_map = dead_pixels_sigma_rate(normalized, norm_mean, norm_dev, sigma=dead_sigma_threshold)
         elif dead_search_type == 'absolute_rate':
+            if max_dead_norm_signal == None:
+                max_dead_norm_signal = get_max_dead_norm_signal_default(instrument=instrument, detector=detector)
+
+            print(max_dead_norm_signal)
             dead_map = dead_pixels_absolute_rate(normalized, max_dead_signal=max_dead_norm_signal)
         dead_map = pad_with_refpix(dead_map, instrument)
 
@@ -725,6 +730,35 @@ def get_fastaxis(filename):
             print(e)
     return fastaxis, slowaxis
 
+
+def get_max_dead_norm_signal_default(instrument, detector):
+    """
+    Finds the default max_dead_norm_signal value to use for the 
+    absolute_rate dead pixel search type.
+
+    Parameters
+    ----------
+    instrument : str
+        The name of the instrument
+    
+    detector : str
+        The name of the detector
+
+    Returns
+    -------
+    default_value : float
+        The default max_dead_norm_signal value
+    """
+    if instrument == 'NIRCAM':
+        detectors = ['NRCA1', 'NRCA2', 'NRCA3', 'NRCA4', 'NRCALONG', 
+                     'NRCB1', 'NRCB2', 'NRCB3', 'NRCB4', 'NRCBLONG']
+        defaults = [25.0, 25.0, 30.0, 30.0, 40.0, 
+                    25.0, 25.0, 25.0, 25.0, 50.0]
+        default_value = defaults[detectors==detector]
+    else:
+        default_value = 0.05
+
+    return default_value
 
 def image_stats(image, sigma=3.):
     """Calculate the sigma-clipped mean and standard deviation across the


### PR DESCRIPTION
This automatically finds the default `max_dead_norm_signal` value to use in the absolute_rate dead pixel search (if none is provided), which varies for the NIRCAM detectors, but remains at 0.05 for all other instruments.

I decided to keep this all together in `bad_pixel_mask.py` and just made it obvious where the defaults are coming from by naming the function `get_max_dead_norm_signal_default()` before the `dead_pixels_absolute_rate()` call.