### PR TITLE
Fixed max_dead_norm_signal bug for open and low qe search

### DIFF
--- a/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
+++ b/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
@@ -242,6 +242,10 @@ def find_bad_pix(input_files, dead_search=True, low_qe_and_open_search=True, dea
 
     # Find low qe and open pixels
     if low_qe_and_open_search:
+        if max_dead_norm_signal is None:
+            max_dead_norm_signal = get_max_dead_norm_signal_default(instrument=instrument, 
+                                                                    detector=detector,
+                                                                    normalization_method=normalization_method.lower())
         lowqe_map, open_map, adjacent_to_open_map = find_open_and_low_qe_pixels(normalized,
                                                                                 max_dead_signal=max_dead_norm_signal,
                                                                                 max_low_qe=max_low_qe_norm_signal,


### PR DESCRIPTION
I found out that the code fails if `dead_search_type` is zero_signal or sigma_rate AND `low_qe_and_open_search` was True.

The `find_open_and_low_qe_pixels` function uses `max_dead_norm_signal` as input, which I changed to None by default, so None gets passed here instead of a float. I think this simple change fixes this scenario.