### PR TITLE
Update strun command for proper output directory

### DIFF
--- a/jwst_reffiles/pipeline/calib_prep.py
+++ b/jwst_reffiles/pipeline/calib_prep.py
@@ -898,11 +898,16 @@ class CalibPrep:
                 # Add step-specific options for saving
                 finstep = steps.split(',')[-1]
                 final_step = step_names[finstep]
-                out_text += (' --steps.{}.suffix={} --steps.{}.output_dir={} --steps.{}.save_results=True'
-                             .format(final_step, added_suffix, final_step, self.output_dir, final_step))
+                #out_text += (' --steps.{}.suffix={} --steps.{}.output_dir={} --steps.{}.save_results=True'
+                #             .format(final_step, added_suffix, final_step, self.output_dir, final_step))
+                out_text += (' --steps.{}.output_file={} --steps.{}.save_results=True'
+                             .format(final_step, outfile_base, final_step))
+
+                # Output directory
+                out_dir = ' --output_dir={}'.format(self.output_dir)
 
                 # Put the whole command together
-                cmd = with_file + skip_text + out_text  # +override_text
+                cmd = with_file + skip_text + out_text + out_dir
 
                 # Since we are getting the output from the final step directly
                 # we can turn off the output from the pipeline

--- a/tests/test_calib_prep.py
+++ b/tests/test_calib_prep.py
@@ -156,30 +156,39 @@ def strun_command_test(cp_object):
     torun2 = 'dq_init,superbias,refpix'
     torun3 = 'dark_current,linearity,rate'
     steps_to_run = Column(data=[torun1, torun2, torun3])
-    out_names = ['dummy_sat_superbias_dark_jump.fits', 'dummy_dq_init_superbias_refpix.fits',
-                 'dummy_dark_linearity_rate.fits']
+    out_names = ['dummy_sat_superbias_dark_jump', 'dummy_dq_init_superbias_refpix',
+                 'dummy_dark_linearity_rate']
     suffixes = ['sat_superbias_dark_jump', 'dq_init_superbias_refpix', 'dark_linearity_rate']
     output_filename = Column(data=out_names)
     constructed_commands = cp_object.strun_command(input_names, steps_to_run, output_filename, testing=True)
     pipeline_cfg_file = os.path.join(cp_object.output_dir, 'calwebb_detector1.cfg')
     truth1 = ('strun {} {} --steps.group_scale.skip=True --steps.dq_init.skip=True --steps.ipc.skip=True '
               '--steps.refpix.skip=True --steps.linearity.skip=True --steps.persistence.skip=True '
-              '--steps.ramp_fit.skip=True --steps.jump.suffix={} --steps.jump.output_dir={}'
-              ' --steps.jump.save_results=True --save_results=False --steps.refpix.odd_even_rows=False'
-              .format(pipeline_cfg_file, in_names[0], suffixes[0], cp_object.output_dir))
+              '--steps.ramp_fit.skip=True --steps.jump.output_file={} --steps.jump.save_results=True '
+              '--output_dir={} --save_results=False --steps.refpix.odd_even_rows=False'
+              .format(pipeline_cfg_file, in_names[0], out_names[0], cp_object.output_dir))
     truth2 = ('strun {} {} --steps.group_scale.skip=True --steps.saturation.skip=True --steps.ipc.skip=True '
               '--steps.linearity.skip=True --steps.persistence.skip=True --steps.dark_current.skip=True '
-              '--steps.jump.skip=True --steps.ramp_fit.skip=True --steps.refpix.suffix={}'
-              ' --steps.refpix.output_dir={} --steps.refpix.save_results=True --save_results=False '
+              '--steps.jump.skip=True --steps.ramp_fit.skip=True --steps.refpix.output_file={} '
+              '--steps.refpix.save_results=True --output_dir={} --save_results=False '
               '--steps.refpix.odd_even_rows=False'
-              .format(pipeline_cfg_file, in_names[1], suffixes[1], cp_object.output_dir))
+              .format(pipeline_cfg_file, in_names[1], out_names[1], cp_object.output_dir))
     truth3 = ('strun {} {} --steps.group_scale.skip=True --steps.dq_init.skip=True --steps.saturation.skip=True '
               '--steps.ipc.skip=True --steps.superbias.skip=True --steps.refpix.skip=True '
-              '--steps.persistence.skip=True --steps.jump.skip=True --steps.ramp_fit.suffix={}'
-              ' --steps.ramp_fit.output_dir={} --steps.ramp_fit.save_results=True --save_results=False '
+              '--steps.persistence.skip=True --steps.jump.skip=True --steps.ramp_fit.output_file={} '
+              '--steps.ramp_fit.save_results=True --output_dir={} --save_results=False '
               '--steps.refpix.odd_even_rows=False'
-              .format(pipeline_cfg_file, in_names[2], suffixes[2], cp_object.output_dir))
+              .format(pipeline_cfg_file, in_names[2], out_names[2], cp_object.output_dir))
     truths = [truth1, truth2, truth3]
+
+
+    print('')
+    print(constructed_commands[2])
+    print('')
+    print(truth3)
+    print('')
+
+
     assert truths == constructed_commands
 
 

--- a/tests/test_calib_prep.py
+++ b/tests/test_calib_prep.py
@@ -183,9 +183,9 @@ def strun_command_test(cp_object):
 
 
     print('')
-    print(constructed_commands[2])
+    print(constructed_commands[0])
     print('')
-    print(truth3)
+    print(truth1)
     print('')
 
 


### PR DESCRIPTION
This PR updates the contents of the generated strun commands in order to place all outputs in the proper output directory. Note that due to the way the pipeline works at the moment, each strun command will produce 2 output files. One will be the requested output from the proper pipeline step. The other will be a *_ramp.fits file which is the output from the pipeline. I haven't found a way to turn off the production of the latter without screwing up the presence or the output name of the former. These changes were made based on experiments using version 0.13.8a of the jwst pipeline.