### PR TITLE
MIRI review changes

### DIFF
--- a/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
+++ b/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
@@ -1027,8 +1027,11 @@ def miri_bad_columns(dimensions):
     shorted_map : numpy.ndarray
         2D map showing the locations of the shorted columns (1)
     """
+
+    print('*************',dimensions)
+
     shorted_map = np.zeros(dimensions).astype(np.int)
-    shorted_map[:, 385:387] = 1
+    shorted_map[:, 384:386] = 1
     return shorted_map
 
 

--- a/jwst_reffiles/dark_current/badpix_from_darks.py
+++ b/jwst_reffiles/dark_current/badpix_from_darks.py
@@ -865,7 +865,9 @@ def plot_image(image, image_max, titleplot, fileout):
     """
     fig = plt.figure(figsize=(9, 9))
     ax1 = fig.add_subplot(1, 1, 1)
-    im = ax1.imshow(image, extent=[0, 1023, 0, 1023], interpolation='None',
+    ysize = image.shape[0]
+    xsize = image.shape[1]
+    im = ax1.imshow(image, extent=[0, xsize, 0, ysize], interpolation='None',
                     cmap=cm.RdYlGn, origin='lower', vmin=0, vmax=image_max)
     plt.colorbar(im)
 
@@ -899,7 +901,7 @@ def plot_histogram_stats(data_array, sigma_threshold, nbins, titleplot, fileout)
       prints the plot to disk
 
     """
-    # plot 1 image of the stat array
+    
     ave = np.mean(data_array)
     std = np.std(data_array)
     xhigh = ave + std*sigma_threshold


### PR DESCRIPTION
Summary of changes
1.  For MIRI data: adjusted pedestal to be pedestal = group2 - pedestal.  Kept the original pedestal for marking saturated pixels
2. added 2 plotting routines for noisy pixels
3. added a routine: read_slope_integration - to replace read_slope_file to handle reading in multiple integrations when there are different number of integration in different exposures. Vstack did not work for multiple integration data when the number of integrations varied between exposures 
4. Pulled out saturated data based on DQ flag of group 1 from the low_pedestal flagging