### PR TITLE
Straighten up filenames of files to be read in

### DIFF
--- a/jwst_reffiles/utils/constants.py
+++ b/jwst_reffiles/utils/constants.py
@@ -1,0 +1,7 @@
+#! /usr/bin/env python
+
+"""This file contains constants that may be useful across multiple
+jwst_reffiles modules
+"""
+
+RATE_FILE_SUFFIXES = ['_0_ramp_fit', '_1_ramp_fit', '_ramp_fit_0', '_ramp_fit_1']


### PR DESCRIPTION
This PR fixes up and streamlines the conventions for creating the filenames to look for and read in. I've added a list of possible slope file suffixes. Right now this includes 0_ramp_fit, 1_ramp_fit, ramp_fit_0 and ramp_fit_1. Users should provide whatever files they have as input. The method to read the data in should be the same regardless of filename suffix. The code now checks to see if a file exists before trying to read it in. I also added similar checks before reading in the pedestal and jump files. 

I also added an index parameter to read_slope_integrations, such that later in the code it is easy to pull out only the integrations that correspond to a particular file. This way the slope files don't need to be read in a second time (i.e. read_slope_data is no longer used). 

This worked for my test case with a series of 0_ramp_fit files for NIRCam. I think it should work just as well for the 1_ramp_fit files for MIRI (in theory you could provide a list of mixed 0_ramp_fit and 1_ramp_fit files and it should still work). 

@jemorrison do you want to try out this branch now, or should I merge it first and you can try it from the master branch?