### PR TITLE
Remove astroconda-dev channel in favor of astroconda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,57 +11,38 @@ os:
 # Setting sudo to false opts in to Travis-CI container-based builds.
 sudo: false
 
-# The apt packages below are needed for sphinx builds, which can no longer
-# be installed with sudo apt-get.
-addons:
-    apt:
-        packages:
-            - graphviz
-            - texlive-latex-extra
-            - dvipng
-
 env:
     global:
-        - MAIN_CMD='python setup.py'
-        - CONDA_CHANNELS='http://ssb.stsci.edu/astroconda'
-        - CONDA_DEPENDENCIES='pytest=3.6 sphinx jwst'
-        - PIP_DEPENDENCIES=''
         - PYTHON_VERSION=3.6
-        - NUMPY_VERSION=stable
-        - ASTROPY_VERSION=stable
         - EVENT_TYPE='push pull_request'
 
-    matrix:
-        - SETUP_CMD='install'
-        - SETUP_CMD='test'
-
 matrix:
-
-    # Don't wait for allowed failures
-    fast_finish: true
-
     include:
-        # build sphinx documentation with warnings
-        - os: linux
-          env: SETUP_CMD='build_sphinx'
-               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
-               PIP_DEPENDENCIES='sphinx_rtd_theme stsci_rtd_theme sphinx-automodapi nbsphinx'
+        # Run pytest suite
+        - name: test linux
+          os: linux
 
-        # PEP8 check with flake8 (only once, i.e. "os: linux")
-        - os: linux
-          env: MAIN_CMD='flake8 --count'
-               SETUP_CMD='jwst_reffiles'
-               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
+        # Run pytest suite
+        - name: test osx
+          os: osx
+          osx_image: xcode10.2
 
-    allow_failures:
-        # PEP8 will fail for numerous reasons. Ignore it.
-        - env: MAIN_CMD='flake8 --count'
-               SETUP_CMD='jwst_reffiles'
-               CONDA_DEPENDENCIES=$CONDA_DEPENDENCIES
-
-install:
+before_install:
     - git clone git://github.com/astropy/ci-helpers.git
     - source ci-helpers/travis/setup_conda_$TRAVIS_OS_NAME.sh
 
+install:
+    # Remove WebbPSF conda install
+    #- sed '/webbpsf/d' environment.yml
+    # Install jwst_reffile dependencies
+    - conda env update -f=environment.yml
+    # Install development versions of webbpsf and poppy
+    #- git clone git://github.com/spacetelescope/poppy.git
+    #- git clone git://github.com/spacetelescope/webbpsf.git
+    #- pip install -e poppy/
+    #- pip install -e webbpsf/
+    # Install jwst_reffiles package
+    - pip install -e .
+
 script:
-    - $MAIN_CMD $SETUP_CMD
+    - pytest ./tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
 env:
     global:
         - MAIN_CMD='python setup.py'
-        - CONDA_CHANNELS='http://ssb.stsci.edu/astroconda-dev'
+        - CONDA_CHANNELS='http://ssb.stsci.edu/astroconda'
         - CONDA_DEPENDENCIES='pytest=3.6 sphinx jwst'
         - PIP_DEPENDENCIES=''
         - PYTHON_VERSION=3.6

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,6 @@ dependencies:
 - crds>=7.4.1
 - gwcs>=0.10a.dev21+g75e92da
 - healpy>=1.10
-- jwst>=0.12.0a.dev115+g9d5eb8c
 - jwxml>=0.3.0
 - matplotlib>=3.0.0
 - numpy>=1.16

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,25 @@
+channels:
+- http://ssb.stsci.edu/astroconda
+- conda-forge
+- defaults
+dependencies:
+- asdf>=2.1.0.dev1+ga161518
+- astropy>=3.2.1
+- crds>=7.4.1
+- gwcs>=0.10a.dev21+g75e92da
+- healpy>=1.10
+- jwst>=0.12.0a.dev115+g9d5eb8c
+- jwxml>=0.3.0
+- matplotlib>=3.0.0
+- numpy>=1.16
+- photutils>=0.6
+- pip>=18.0
+- pytest>=3.8.1
+- python>=3.6,<3.7
+- pyyaml>=5.1.1
+- scipy>=1.1.0
+- sphinx>=2.1
+- yaml>=0.1.7
+- pip:
+    - git+https://github.com/spacetelescope/jwst@0.13.8
+    - pysiaf>0.3.0

--- a/tests/test_bad_pixel_mask.py
+++ b/tests/test_bad_pixel_mask.py
@@ -2,6 +2,7 @@
 
 """Tests for bad_pixel_mask.py"""
 
+from astropy.io import fits
 import numpy as np
 from jwst.datamodels import dqflags
 
@@ -133,7 +134,11 @@ def test_extract_10th_group():
     test = np.zeros((2, 12, 3, 3))
     test[0, 9, :, :] = 1.
     test[1, 9, :, :] = 2.
-    extracted = bpm.extract_10th_group(test)
+    hdu0 = fits.PrimaryHDU(test)
+    hdu0.header['FILENAME'] = 'test.fits'
+    hdu0.header['EXTNAME'] = 'SCI'
+    hdu_list = fits.HDUList([hdu0])
+    extracted = bpm.extract_10th_group(hdu_list)
     manual = np.zeros((2, 3, 3))
     manual[0, :, :] = 1.
     manual[1, :, :] = 2.
@@ -141,7 +146,11 @@ def test_extract_10th_group():
 
     test = np.zeros((12, 3, 3))
     test[9, :, :] = 3.
-    extracted = bpm.extract_10th_group(test)
+    hdu0 = fits.PrimaryHDU(test)
+    hdu0.header['FILENAME'] = 'test.fits'
+    hdu0.header['EXTNAME'] = 'SCI'
+    hdu_list = fits.HDUList([hdu0])
+    extracted = bpm.extract_10th_group(hdu_list)
     manual = np.zeros((1, 3, 3))
     manual[0, :, :] = 3.
     assert np.all(extracted == manual)
@@ -181,9 +190,14 @@ def test_smooth():
     width = 3
     test = np.arange(25).reshape(5, 5)
     smoothed = bpm.smooth(test, box_width=width)
-    truth = np.array([[1.33333333,  2.33333333,  3.,  3.66666667,  2.66666667],
-                      [3.66666667,  6.,  7.,  8.,  5.66666667],
-                      [7., 11., 12., 13.,  9.],
-                      [10.33333333, 16., 17., 18., 12.33333333],
-                      [8., 12.33333333, 13., 13.66666667, 9.33333333]])
+    #truth = np.array([[1.33333333,  2.33333333,  3.,  3.66666667,  2.66666667],
+    #                  [3.66666667,  6.,  7.,  8.,  5.66666667],
+    #                  [7., 11., 12., 13.,  9.],
+    #                  [10.33333333, 16., 17., 18., 12.33333333],
+    #                  [8., 12.33333333, 13., 13.66666667, 9.33333333]])
+    truth = np.array([[ 8.        ,  6.33333333,  7.        ,  7.66666667,  9.33333333],
+                      [ 7.66666667,  6.        ,  7.        ,  8.        ,  9.66666667],
+                      [11.        , 11.        , 12.        , 13.        , 13.        ],
+                      [14.33333333, 16.        , 17.        , 18.        , 16.33333333],
+                      [14.66666667, 16.33333333, 17.        , 17.66666667, 16.        ]])
     assert np.allclose(smoothed, truth, atol=1e-6, rtol=0)


### PR DESCRIPTION
This PR removes the astroconda-dev channel from the Travis setup file. astroconda-dev no longer exists which is causing Travis to fail. Hopefully this will fix the failing tests.