### PR TITLE
Readnoise mkrefs

### DIFF
--- a/jwst_reffiles/mkrefs.cfg
+++ b/jwst_reffiles/mkrefs.cfg
@@ -1,11 +1,10 @@
 instrument: NIRCam
-#reflabels: [bad_pixel_mask,gain_armin,bpm,rdnoise_nircam]
-reflabels: [bad_pixel_mask]
-reftypes: [bpm,rdnoise,gain,linearity]
+reflabels: [bad_pixel_mask, readnoise, gain_armin]
+reftypes: [bpm, rdn, gain, linearity]
 
 default_reflabels:
    bpm: bad_pixel_mask
-   rdnoise: rdnoise_nircam
+   rdn: readnoise
    gain: gain_armin
 
 inputfiles:
@@ -66,7 +65,6 @@ output:
    # reference file is saved in a log,
    # same name as reference filename, but with suffix err.txt
    referrorlogFlag: True
-   
 
    # directories in which ssb products are looked for. comma-separated list!
    pipeline_prod_search_dir:
@@ -80,9 +78,9 @@ test2: 5
 
 # values allowed: CRDS, SELF, filepattern
 reffile4ssb:
-   gain: CRDS
    bpm: CRDS
-   rdnoise: CRDS
+   rdn: CRDS
+   gain: CRDS
 
 # after a reference file is created, run the following tests:
 # (1) load it into the appropriate data model
@@ -92,14 +90,14 @@ test4ssb: True
 
 # values allowed: CRDS, filename
 validation:
-   gainreffile: CRDS
    bpmreffile: CRDS
+   rdnreffile: CRDS
+   gainreffile: CRDS
 
 bad_pixel_mask:
     reftype: bpm
     imtypes: F+
-#    ssbsteps: rate-
-    ssbsteps: refpix-
+    ssbsteps: rate-
     dead_search: True
     low_qe_and_open_search: True
     dead_search_type: 'zero_signal'
@@ -118,6 +116,25 @@ bad_pixel_mask:
     history: 'This file was made using mkrefs.py'
     quality_check: False
 
+readnoise:
+    reftype: rdn
+    imtypes: D+
+    ssbsteps: group_scale, dq_init, saturation, superbias, refpix
+    method: 'ramp'
+    group_diff_type: 'independent'
+    clipping_sigma: 3.0
+    max_clipping_iters: 3
+    nproc: 1 
+    slice_width: 50
+    author: 'jwst_reffiles'
+    description: 'CDS Noise Image'
+    pedigree: 'GROUND'
+    useafter: '2019-01-01T00:00:00'
+    history: 'This file was made using mkrefs.py'
+    subarray: 'GENERIC'
+    readpatt: 'ANY'
+    save_tmp: False
+
 example_bpm:
     reftype: bpm
     imtypes: DDFF
@@ -133,12 +150,6 @@ example_bpm:
     useafter: '2019-04-01 00:00:00'
     history: 'This file was made using mkrefs.py'
     quality_check: False
-
-rdnoise_nircam:
-    reftype: rdnoise
-    imtypes: DD
-    ssbsteps: dq_init
-    test1: 6
 
 gain_armin:
     reftype: gain

--- a/jwst_reffiles/readnoise/mkref_readnoise.py
+++ b/jwst_reffiles/readnoise/mkref_readnoise.py
@@ -1,0 +1,113 @@
+#! /usr/bin/env python
+
+"""
+Plug-in script for the readnoise reffile creation module:
+readnoise.py, which uses the readnoise generation algorithms
+decided upon by the JWST reference file generation working group.
+This class is based on that in the
+template file: jwst_reffiles/templates/plugin_template.py
+"""
+
+import argparse
+import copy
+import os
+import re
+import sys
+import types
+
+from jwst_reffiles.plugin_wrapper import mkrefclass_template
+
+# import the readnoise script
+from jwst_reffiles.readnoise import readnoise
+
+class mkrefclass(mkrefclass_template):
+    def __init__(self, *args, **kwargs):
+        mkrefclass_template.__init__(self, *args, **kwargs)
+
+        # Set the reflabel as the name of the imported module
+        self.reflabel = 'readnoise'
+
+        # Set the reftype
+        self.reftype = 'rdn'
+
+    def extra_optional_arguments(self, parser):
+        """Any arguments added here will give the option of overriding
+        the default argument values present in the config file. To override,
+        call these arguments from the command line in the call to mkrefs.py
+        """
+
+        parser.add_argument('--method', help=('The method to use when calculating the readnoise. '
+                                              'Options are: stack and ramp'))
+        parser.add_argument('--group_diff_type', help=('The method for calculating group differences. '
+                                                       'Options are: independent and consecutive'))
+        parser.add_argument('--clipping_sigma', help=('Number of sigma to use when sigma-clipping.'))
+        parser.add_argument('--max_clipping_iters', help=('Maximum number of iterations to use when '
+                                                          'sigma-clipping.'))
+        parser.add_argument('--nproc', help=('The number of processes to use during multiprocessing. '))
+        parser.add_argument('--slice_width', help=('The width (in pixels) of the image slice to use '
+                                                   'during multiprocessing. The readnoise of each slice '
+                                                   'is calculated separately during multiprocessing and '
+                                                   'combined together at the end of processing. Only '
+                                                   'relevant if method==stack.'))
+        parser.add_argument('--author', help=('CRDS-required name of the reference file author, to be '
+                                              'placed in the referece file header.'))
+        parser.add_argument('--description', help=('CRDS-required description of the reference file, to '
+                                                   'be placed in the reference file header.'))
+        parser.add_argument('--pedigree', help=('CRDS-required pedigree of the data used to create the '
+                                                'reference file.'))
+        parser.add_argument('--useafter', help=('CRDS-required date of earliest data with which this '
+                                                'reffile should be used. (e.g. 2019-04-01T00:00:00).'))
+        parser.add_argument('--history', help=('CRDS-required history section to place in the reference '
+                                               'file header.'))
+        parser.add_argument('--subarray', help=('CRDS-required subarray for which to use this reference '
+                                                'file for.'))
+        parser.add_argument('--readpatt', help=('CRDS-required read pattern for which to use this '
+                                                'reference file for.'))
+        parser.add_argument('--save_tmp', help=('Option to save the final readnoise map before turning it '
+                                                'into CRDS format. This is useful if the CRDS transformation '
+                                                'fails; in this scenario, you wont lose all of the final '
+                                                'readnoise results so all of the previous processing wasnt '
+                                                'for nothing.'))
+
+        return(0)
+
+    def callalgorithm(self):
+        """Call the readnoise algorithm. The only requirement is that the output
+        reference file is saved as self.args.outputreffilename
+
+        mkrefs.py will supply the input files in self.inputimages['output_name'].
+        This will be a list containing the filenames to use as input. The
+        file types (e.g. dark, flat) associated with each filename are
+        contained in self.inputimages['imtype']. From this, you can specify
+        the appropriate file names in the call to your module.
+        """
+
+        # Call the wrapped module and provide the proper arguments from the
+        # self.parameters dictionary.
+        readnoise.make_readnoise(self.inputimages,
+                                 method=self.parameters['method'],
+                                 group_diff_type=self.parameters['group_diff_type'], 
+                                 clipping_sigma=self.parameters['clipping_sigma'], 
+                                 max_clipping_iters=self.parameters['max_clipping_iters'], 
+                                 nproc=self.parameters['nproc'], 
+                                 slice_width=self.parameters['slice_width'], 
+                                 outfile=self.args.outputreffilename, 
+                                 author=self.parameters['author'], 
+                                 description=self.parameters['description'], 
+                                 pedigree=self.parameters['pedigree'], 
+                                 useafter=self.parameters['useafter'], 
+                                 history=self.parameters['history'], 
+                                 subarray=self.parameters['subarray'], 
+                                 readpatt=self.parameters['readpatt'], 
+                                 save_tmp=self.parameters['save_tmp'])
+
+        return(0)
+
+
+if __name__ == '__main__':
+    """This should not need to be changed. This will read in the config
+    files, import the script, generate the self.parameters dictionary, and
+    run the argument parser above.
+    """
+    mkref = mkrefclass()
+    mkref.make_reference_file()


### PR DESCRIPTION
These changes get the readnoise reffile code working with mkrefs. The following is what I changed:
- added new readnoise section to the config file
- added a 'D+' option to mkrefs since the readnoise code takes in a collection of darks and returns one readnoise file
- added the mkrefs plugin script of the readnoise code `mkref_readnoise.py`
- minor changes to the readnoise code (e.g. allowed option to save temporary files in case of crashes) 

I've run different variations of mkrefs calls/options with this and everything looks good - for example, I get the same final results running the pipeline manually+then running the readnoise code directly on those calibrated files as I do running it through mkrefs with uncal files. I just wanted to give you the option to review it since it's my first time working with mkrefs, but the process of plugging it into mkrefs was very straightforward!
