### PR TITLE
Integrate bad_pixel_mask into mkrefs

### DIFF
--- a/jwst_reffiles/bad_pixel_mask/mkref_badpix_from_flats.py
+++ b/jwst_reffiles/bad_pixel_mask/mkref_badpix_from_flats.py
@@ -17,7 +17,7 @@ import types
 from jwst_reffiles.plugin_wrapper import mkrefclass_template
 
 # import the bad pixel mask script
-from jwst_reffiles.bad_pixel_mask import bad_pixel_mask as bpm
+from jwst_reffiles.bad_pixel_mask.badpix_from_flats import find_bad_pix as bpm
 from jwst_reffiles.utils.definitions import PIPE_STEPS
 
 
@@ -26,7 +26,7 @@ class mkrefclass(mkrefclass_template):
         mkrefclass_template.__init__(self, *args, **kwargs)
 
         # Set the reflabel as the name of the imported module
-        self.reflabel = 'bad_pixel_mask'
+        self.reflabel = 'badpix_from_flats'
 
         # Set the reftype
         self.reftype = 'bpm'

--- a/jwst_reffiles/mkrefs.cfg
+++ b/jwst_reffiles/mkrefs.cfg
@@ -1,13 +1,12 @@
 instrument: NIRCam
 #reflabels: [bad_pixel_mask,gain_armin,bpm,rdnoise_nircam]
-reflabels: [dark]
-reftypes: [dark,rdnoise,gain,linearity]
+reflabels: [bad_pixel_mask]
+reftypes: [bpm,rdnoise,gain,linearity]
 
 default_reflabels:
    bpm: bad_pixel_mask
    rdnoise: rdnoise_nircam
    gain: gain_armin
-   dark: dark
 
 inputfiles:
    dark_pattern: Bias|Dark|BIAS|DARK|ZERO
@@ -84,7 +83,6 @@ reffile4ssb:
    gain: CRDS
    bpm: CRDS
    rdnoise: CRDS
-   dark: CRDS
 
 # after a reference file is created, run the following tests:
 # (1) load it into the appropriate data model
@@ -96,47 +94,45 @@ test4ssb: True
 validation:
    gainreffile: CRDS
    bpmreffile: CRDS
-   darkreffile: CRDS
-
-dark:
-    reftype: dark
-    imtypes: D+
-    ssbsteps: dq_init, saturation, superbias, refpix, linearity, jump
-    max_equivalent_groups: 60
-    sigma_threshold: 3
-    contribution_file: 'good_signals_per_group.pdf'
-    pedigree: 'GROUND'
-    use_after: '2037-09-30'
-    author: 'I. C. Nothing'
-    descrip: 'New dark current file made using mkrefs'
-    history: 'This is a long history entry. At the moment, mkrefs is not smart enough to look for multi-line strings, which means this is going to have to be a single long string, which will be split and placed into the HISTORY keyword of the reference file, along with the list of input files used to create the reference file.'
 
 bad_pixel_mask:
     reftype: bpm
-    imtypes: F+
-#    ssbsteps: rate-
-    ssbsteps: refpix-
+    imtypes: DF+
+    ssbsteps: rate-
+    ssb_save_steps: jump, fitopt
     dead_search: True
     low_qe_and_open_search: True
-    dead_search_type: 'zero_signal'
-    sigma_threshold: 3
+    dead_search_type: sigma_rate
+    flat_mean_sigma_threshold: 3
+    flat_mean_normalization_method: smoothed
     smoothing_box_width: 15
+    smoothing_type: Box2D
     dead_sigma_threshold: 5.
-    dead_zero_signal_fraction: 0.9
+    max_dead_norm_signal: None
     run_dead_flux_check: True
-    dead_flux_check: None
-    max_dead_norm_signal: 0.05
-    maual_flag_file: 'default'
+    flux_check: 45000
     max_low_qe_norm_signal: 0.5
     max_open_adj_norm_signal: 1.05
-    do_not_use: ['DEAD', 'LOW_QE', 'OPEN', 'ADJ_OPEN']
-    output_file: none
-    author: 'jwst_reffiles'
-    description: 'This is a bad pixel mask'
-    pedigree: 'GROUND'
+    manual_flag_file: default
+    dark_stdev_clipping_sigma: 5.
+    dark_max_clipping_iters: 5
+    dark_noisy_threshold: 5
+    max_saturated_fraction: 0.5
+    max_jump_limit: 10
+    jump_ratio_threshold: 5
+    early_cutoff_fraction: 0.25
+    pedestal_sigma_threshold: 5
+    rc_fraction_threshold: 0.8
+    low_pedestal_fraction: 0.8
+    high_cr_fraction: 0.8
+    plot: False
+    author: 'A. Hard Worker'
+    description: 'A bad pix mask'
+    pedigree: GROUND
     useafter: '2019-04-01 00:00:00'
-    history: 'This file was made using mkrefs.py'
+    history: 'This bad pixel file was created by jwst_reffiles'
     quality_check: False
+
 
 example_bpm:
     reftype: bpm

--- a/jwst_reffiles/mkrefs.cfg
+++ b/jwst_reffiles/mkrefs.cfg
@@ -1,12 +1,13 @@
 instrument: NIRCam
 #reflabels: [bad_pixel_mask,gain_armin,bpm,rdnoise_nircam]
-reflabels: [bad_pixel_mask]
-reftypes: [bpm,rdnoise,gain,linearity]
+reflabels: [bad_pixel_mask,dark]
+reftypes: [bpm,dark,rdnoise,gain,linearity]
 
 default_reflabels:
    bpm: bad_pixel_mask
    rdnoise: rdnoise_nircam
    gain: gain_armin
+   dark: dark
 
 inputfiles:
    dark_pattern: Bias|Dark|BIAS|DARK|ZERO
@@ -83,6 +84,7 @@ reffile4ssb:
    gain: CRDS
    bpm: CRDS
    rdnoise: CRDS
+   dark: CRDS
 
 # after a reference file is created, run the following tests:
 # (1) load it into the appropriate data model
@@ -94,6 +96,21 @@ test4ssb: True
 validation:
    gainreffile: CRDS
    bpmreffile: CRDS
+   darkreffile: CRDS
+
+dark:
+    reftype: dark
+    imtypes: D+
+    ssbsteps: dq_init, saturation, superbias, refpix, linearity, jump
+    ssb_save_steps: None
+    max_equivalent_groups: 60
+    sigma_threshold: 3
+    contribution_file: 'good_signals_per_group.pdf'
+    pedigree: 'GROUND'
+    use_after: '2037-09-30'
+    author: 'I. C. Nothing'
+    descrip: 'New dark current file made using mkrefs'
+    history: 'This is a long history entry. At the moment, mkrefs is not smart enough to look for multi-line strings, which means this is going to have to be a single long string, which will be split and placed into the HISTORY keyword of the reference file, along with the list of input files used to create the reference file.'
 
 bad_pixel_mask:
     reftype: bpm
@@ -138,6 +155,7 @@ example_bpm:
     reftype: bpm
     imtypes: DDFF
     ssbsteps: refpix-
+    ssb_save_steps: None
     # after a reference file is created, run the following tests:
     # (1) load it into the appropriate data model
     # (2) run it through ssb
@@ -154,12 +172,14 @@ rdnoise_nircam:
     reftype: rdnoise
     imtypes: DD
     ssbsteps: dq_init
+    ssb_save_steps: None
     test1: 6
 
 gain_armin:
     reftype: gain
     imtypes: DDFF
     ssbsteps: superbias-
+    ssb_save_steps: None
     reffile4ssb:
         bpmreffile: /bla/bpm.fits
 
@@ -167,6 +187,7 @@ gain_bryan:
     reftype: gain
     imtypes: FF
     ssbsteps: rate-
+    ssb_save_steps: None
     reffile4ssb:
         bpmreffile: /bla/bpm.fits
 

--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -12,6 +12,7 @@ from logging.handlers import RotatingFileHandler
 
 import astropy.io.fits as fits
 from astropy.io import ascii
+from astropy.table import vstack
 import astropy
 import numpy as np
 import scipy
@@ -831,7 +832,7 @@ class mkrefsclass(astrotableclass):
         '''
         returns list of Dark-Dark pair indeces,  where the indices refer to the self.imtable table
         '''
-        self.logger.debug('# Getting DD list')
+        #logger.debug('# Getting DD list')
         #self.imtable.t['skip'][7]=True
         #print  self.imtable.t[6:11]
 
@@ -840,33 +841,33 @@ class mkrefsclass(astrotableclass):
         # indices for detector and not skipped
         dindex4detector = dindex[np.where(np.logical_and(self.imtable.t['DETECTOR'][dindex] == detector,
                                                          np.logical_not(self.imtable.t['skip'][dindex])))]
-        self.logger.info('Possible %d Darks for detector %s' % (len(dindex4detector), detector))
-        self.logger.info(self.imtable.t[dindex4detector])
+        #logger.info('Possible %d Darks for detector %s' % (len(dindex4detector), detector))
+        #logger.info(self.imtable.t[dindex4detector])
 
         DD = astrotableclass(names=('D1index', 'D2index', 'D1imID', 'D2imID'), dtype=('i4', 'i4', 'i4', 'i4'))
         i = 0
         while i < len(dindex4detector)-1:
             if max_Delta_MJD is not None:
-                self.logger.info('Checking if imID={} and {} can be DD'.format(self.imtable.t['imID'][dindex4detector[i]],
-                                                                           self.imtable.t['imID'][dindex4detector[i+1]]))
+                #logger.info('Checking if imID={} and {} can be DD'.format(self.imtable.t['imID'][dindex4detector[i]],
+                #                                                           self.imtable.t['imID'][dindex4detector[i+1]]))
                 dMJD = self.imtable.t['MJD'][dindex4detector[i+1]]-self.imtable.t['MJD'][dindex4detector[i]]
-                self.logger.debug('dMJD:', dMJD)
+                #logger.debug('dMJD:', dMJD)
                 if dMJD > max_Delta_MJD:
-                    self.logger.info(('Skipping imID={} (MJD={}) since imID={} is not within timelimit (Delta '
-                                  'MJD = {}>{})!'.format(self.imtable.t['imID'][dindex4detector[i]],
-                                                         self.imtable.t['MJD'][i],
-                                                         self.imtable.t['imID'][dindex4detector[i+1]],
-                                                         dMJD, max_Delta_MJD)))
+                    #logger.info(('Skipping imID={} (MJD={}) since imID={} is not within timelimit (Delta '
+                    #              'MJD = {}>{})!'.format(self.imtable.t['imID'][dindex4detector[i]],
+                    #                                     self.imtable.t['MJD'][i],
+                    #                                     self.imtable.t['imID'][dindex4detector[i+1]],
+                    #                                     dMJD, max_Delta_MJD)))
                     i += 1
                     continue
-            self.logger.info('Adding DD pair with imID={} and {}'.format(self.imtable.t['imID'][dindex4detector[i]],
-                                                                     self.imtable.t['imID'][dindex4detector[i+1]]))
+            #logger.info('Adding DD pair with imID={} and {}'.format(self.imtable.t['imID'][dindex4detector[i]],
+            #                                                         self.imtable.t['imID'][dindex4detector[i+1]]))
             DD.t.add_row({'D1index': dindex4detector[i], 'D2index': dindex4detector[i+1],
                           'D1imID': self.imtable.t['imID'][dindex4detector[i]],
                           'D2imID': self.imtable.t['imID'][dindex4detector[i+1]]})
             i += 2
 
-        self.logger.debug(DD.t)
+        #logger.debug(DD.t)
         return(DD, ('D1', 'D2'))
 
     def getDpluslist(self, detector, max_Delta_MJD=None):
@@ -912,7 +913,7 @@ class mkrefsclass(astrotableclass):
         '''
         self.logger.info('# Getting FF list')
 
-        # indices for dark frames
+        # indices for flat frames
         findex, = np.where(self.imtable.t['imtype'] == 'flat')
         # indices for detector and not skipped
         findex4detector = findex[np.where(np.logical_and(self.imtable.t['DETECTOR'][findex] == detector,
@@ -943,84 +944,161 @@ class mkrefsclass(astrotableclass):
 
         return(Fplus,imagelabels)
 
+    def getDplusFpluslist(self, detector, max_Delta_MJD=None):
+        """Create table of mulitple dark and flat exposures. Since everything
+        is in instances of astrotableclass, we can't just vstack the tables.
+        Unfortunately, easiest is to repeat the code in getFpluslist and getDpluslist
+        so that we have access to the column names and datatypes.
+        """
+        self.logger.info('# Getting DF+ list')
+
+        # indices for Flat frames
+        findex, = np.where(self.imtable.t['imtype'] == 'flat')
+
+        # indices for detector and not skipped
+        findex4detector = findex[np.where(np.logical_and(self.imtable.t['DETECTOR'][findex] == detector,
+                                                         np.logical_not(self.imtable.t['skip'][findex])))]
+
+        self.logger.info('{} Flats for detector {}'.format(len(findex4detector), detector))
+
+        for goodrow in self.imtable.t[findex4detector]:
+            row_str = ''
+            for col in self.imtable.t.colnames:
+                row_str = row_str + '  {}'.format(goodrow[col])
+            self.logger.info(row_str)
+
+        if len(findex4detector) >= 1:
+            fcols = ['F%dindex' % i for i in range(1, len(findex4detector)+1)]
+            fcols.extend(['F%dimID' % i for i in range(1, len(findex4detector)+1)])
+            fdtypes = ['i4' for i in range(len(fcols))]
+            fimagelabels = ['F%d' % i for i in range(1, len(findex4detector)+1)]
+        else:
+            fcols = []
+            fimagelabels = []
+
+        # indices for Dark frames
+        dindex, = np.where(self.imtable.t['imtype'] == 'dark')
+
+        # indices for detector and not skipped
+        dindex4detector = dindex[np.where(np.logical_and(self.imtable.t['DETECTOR'][dindex] == detector,
+                                                         np.logical_not(self.imtable.t['skip'][dindex])))]
+
+        self.logger.info('{} Darks for detector {}'.format(len(dindex4detector), detector))
+
+        for goodrow in self.imtable.t[dindex4detector]:
+            row_str = ''
+            for col in self.imtable.t.colnames:
+                row_str = row_str + '  {}'.format(goodrow[col])
+            self.logger.info(row_str)
+
+        if len(findex4detector) >= 1:
+            dcols = ['D%dindex' % i for i in range(1, len(dindex4detector)+1)]
+            dcols.extend(['D%dimID' % i for i in range(1, len(dindex4detector)+1)])
+            ddtypes = ['i4' for i in range(len(dcols))]
+            dimagelabels = ['D%d' % i for i in range(1, len(dindex4detector)+1)]
+        else:
+            dcols = []
+            dimagelabels = []
+
+        all_imagelabels = dimagelabels + fimagelabels
+
+        if ((len(findex4detector) >= 1) or (len(dindex4detector) >= 1)):
+            data_types = ddtypes + fdtypes
+            data_cols = dcols + fcols
+            full_table = astrotableclass(names=data_cols, dtype=data_types)
+        else:
+            full_table = astrotableclass()
+            return all_table, []
+
+        r = full_table.t.add_row({})
+        for i in range(1, len(dindex4detector) + 1):
+            full_table.t['D%dindex' % i][r] = dindex4detector[i - 1]
+            full_table.t['D%dimID' % i][r] = self.imtable.t['imID'][dindex4detector[i - 1]]
+
+        for i in range(1, len(findex4detector) + 1):
+            full_table.t['F%dindex' % i][r] = findex4detector[i - 1]
+            full_table.t['F%dimID' % i][r] = self.imtable.t['imID'][findex4detector[i - 1]]
+
+        return full_table, all_imagelabels
+
     def getFFlist(self, detector, max_Delta_MJD=None):
         '''
         returns list of Flat-Flat pair indeces, where the indices refer to the self.imtable table
         '''
-        self.logger.info('# Getting FF list')
+        #self.logger.info('# Getting FF list')
 
         # indices for dark frames
         findex, = np.where(self.imtable.t['imtype'] == 'flat')
         # indices for detector and not skipped
         findex4detector = findex[np.where(np.logical_and(self.imtable.t['DETECTOR'][findex] == detector,
                                                          np.logical_not(self.imtable.t['skip'][findex])))]
-        self.logger.info('Possible {} Flats for detector {}'.format(len(findex4detector), detector))
-        self.logger.info(self.imtable.t[findex4detector])
+        #self.logger.info('Possible {} Flats for detector {}'.format(len(findex4detector), detector))
+        #self.logger.info(self.imtable.t[findex4detector])
 
         FF = astrotableclass(names=('F1index', 'F2index', 'F1imID', 'F2imID'), dtype=('i4', 'i4', 'i4', 'i4'))
         i = 0
         while i < len(findex4detector)-1:
             if max_Delta_MJD is not None:
-                self.logger.info('Checking if imID={} and {} can be FF'.format(self.imtable.t['imID'][findex4detector[i]],
-                                                                           self.imtable.t['imID'][findex4detector[i+1]]))
+                #self.logger.info('Checking if imID={} and {} can be FF'.format(self.imtable.t['imID'][findex4detector[i]],
+                #                                                           self.imtable.t['imID'][findex4detector[i+1]]))
                 dMJD = self.imtable.t['MJD'][findex4detector[i+1]]-self.imtable.t['MJD'][findex4detector[i]]
-                self.logger.debug('dMJD:', dMJD)
+                #self.logger.debug('dMJD:', dMJD)
                 if dMJD > max_Delta_MJD:
-                    self.logger.info(('Skipping imID={} (MJD={}) since imID={} is not within '
-                                  'timelimit (Delta MJD = {}>{})!').format(self.imtable.t['imID'][findex4detector[i]],
-                                                                           self.imtable.t['MJD'][i],
-                                                                           self.imtable.t['imID'][findex4detector[i+1]],
-                                                                           dMJD, max_Delta_MJD))
+                    #self.logger.info(('Skipping imID={} (MJD={}) since imID={} is not within '
+                    #              'timelimit (Delta MJD = {}>{})!').format(self.imtable.t['imID'][findex4detector[i]],
+                    #                                                       self.imtable.t['MJD'][i],
+                    #                                                       self.imtable.t['imID'][findex4detector[i+1]],
+                    #                                                       dMJD, max_Delta_MJD))
                     i += 1
                     continue
-            self.logger.info('Adding FF pair with imID={} and {}'.format(self.imtable.t['imID'][findex4detector[i]],
-                                                                     self.imtable.t['imID'][findex4detector[i+1]]))
+            #self.logger.info('Adding FF pair with imID={} and {}'.format(self.imtable.t['imID'][findex4detector[i]],
+            #                                                         self.imtable.t['imID'][findex4detector[i+1]]))
             FF.t.add_row({'F1index': findex4detector[i], 'F2index': findex4detector[i+1],
                           'F1imID': self.imtable.t['imID'][findex4detector[i]],
                           'F2imID': self.imtable.t['imID'][findex4detector[i+1]]})
             i += 2
 
-        self.logger.debug(FF.t)
+        #self.logger.debug(FF.t)
         return(FF, ('F1', 'F2'))
 
     def getDDFFlist(self, detector, DD_max_Delta_MJD=None, FF_max_Delta_MJD=None, DDFF_max_Delta_MJD=None):
         '''
         returns list of Flat-Flat pair indeces, where the indices refer to the self.imtable table
         '''
-        logger.info('\n### Getting DDFF list')
+        self.logger.info('\n### Getting DDFF list')
         DD, DDimtypes = self.getDDlist(detector, max_Delta_MJD=DD_max_Delta_MJD)
         FF, FFimtypes = self.getFFlist(detector, max_Delta_MJD=FF_max_Delta_MJD)
-        logger.info('### DD and FF lists created, now matching them!!!')
+        self.logger.info('### DD and FF lists created, now matching them!!!')
 
         DDFF = astrotableclass(names=('F1index', 'F2index', 'F1imID', 'F2imID', 'D1index', 'D2index', 'D1imID',
                                       'D2imID'), dtype=('i4', 'i4', 'i4', 'i4', 'i4', 'i4', 'i4', 'i4'))
         ddcount = np.zeros(len(DD.t))
 
         for f in range(len(FF.t)):
-            logger.debug('# Finding DD pair for FF pair with imID=%d and %d' % (FF.t['F1imID'][f], FF.t['F2imID'][f]))
+            self.logger.debug('# Finding DD pair for FF pair with imID=%d and %d' % (FF.t['F1imID'][f], FF.t['F2imID'][f]))
             if DDFF_max_Delta_MJD is not None:
                 FF_MJDmin = np.amin(np.array((self.imtable.t['MJD'][FF.t['F1index'][f]],
                                               self.imtable.t['MJD'][FF.t['F2index'][f]])))
                 FF_MJDmax = np.amax(np.array((self.imtable.t['MJD'][FF.t['F1index'][f]],
                                               self.imtable.t['MJD'][FF.t['F2index'][f]])))
-                logger.debug('FF MJDs: {} {}'.format(FF_MJDmin, FF_MJDmax))
+                self.logger.debug('FF MJDs: {} {}'.format(FF_MJDmin, FF_MJDmax))
 
             d_best = None
             ddcountmin = None
             for d in range(len(DD.t)):
                 if ddcountmin is None or ddcount[d] < ddcountmin:
                     if DDFF_max_Delta_MJD is not None:
-                        logger.info('# Testing DD pair with imID=%d and %d' % (DD.t['D1imID'][d], DD.t['D2imID'][d]))
+                        self.logger.info('# Testing DD pair with imID=%d and %d' % (DD.t['D1imID'][d], DD.t['D2imID'][d]))
                         DD_MJDmin = np.amin(np.array((self.imtable.t['MJD'][DD.t['D1index'][d]],
                                                       self.imtable.t['MJD'][DD.t['D2index'][d]])))
                         DD_MJDmax = np.amax(np.array((self.imtable.t['MJD'][DD.t['D1index'][d]],
                                                       self.imtable.t['MJD'][DD.t['D2index'][d]])))
-                        logger.info('DD MJD range', DD_MJDmin, DD_MJDmax)
+                        self.logger.info('DD MJD range: {} to {}'.format(DD_MJDmin, DD_MJDmax))
                         dMJD = np.fabs([DD_MJDmax-FF_MJDmin, DD_MJDmin-FF_MJDmax, DD_MJDmax-FF_MJDmax,
                                         DD_MJDmin-FF_MJDmin])
                         max_dMJD = np.amax(dMJD)
                         if max_dMJD > DDFF_max_Delta_MJD:
-                            logger.info('DD pair with imID=%d and %d cannot be used, dMJD=%f>%f' % (DD.t['D1imID'][d],
+                            self.logger.info('DD pair with imID=%d and %d cannot be used, dMJD=%f>%f' % (DD.t['D1imID'][d],
                                                                                                     DD.t['D2imID'][d],
                                                                                                     max_dMJD, DDFF_max_Delta_MJD))
                             continue
@@ -1028,10 +1106,10 @@ class mkrefsclass(astrotableclass):
                     d_best = d
 
             if d_best is None:
-                logger.info('SKIPPING following FF pair since there is no matching DD pair!')
-                logger.info(FF.t[f])
+                self.logger.info('SKIPPING following FF pair since there is no matching DD pair!')
+                self.logger.info(FF.t[f])
             else:
-                logger.info('SUCCESS! DD pair with imID %d and %d found for FF pair with imID %d and %d' % (DD.t['D1imID'][d_best],
+                self.logger.info('SUCCESS! DD pair with imID %d and %d found for FF pair with imID %d and %d' % (DD.t['D1imID'][d_best],
                                                                                                              DD.t['D2imID'][d_best],
                                                                                                              FF.t['F1imID'][f],
                                                                                                              FF.t['F2imID'][f]))
@@ -1062,6 +1140,8 @@ class mkrefsclass(astrotableclass):
             imagesets, imagelabels = self.getFFlist(detector, max_Delta_MJD=FF_max_Delta_MJD)
         elif imtypes == 'F+':
             imagesets, imagelabels = self.getFpluslist(detector)
+        elif imtypes in ['D+F+', 'F+D+', 'DF+', 'FD+']:
+            imagesets, imagelabels = self.getDplusFpluslist(detector)
         elif imtypes == 'DDFF' or imtypes == 'FFDD':
             imagesets, imagelabels = self.getDDFFlist(detector, DD_max_Delta_MJD=DD_max_Delta_MJD,
                                                       FF_max_Delta_MJD=FF_max_Delta_MJD,
@@ -1119,12 +1199,12 @@ class mkrefsclass(astrotableclass):
         #sys.exit(0)
 
         self.inputimagestable = astrotableclass(names=('cmdID', 'reflabel', 'imlabel', 'imtype', 'detector',
-                                                       'ssbsteps', 'imindex', 'imID', 'MJD', 'fitsfile'),
+                                                       'ssbsteps', 'ssb_save_steps', 'imindex', 'imID', 'MJD', 'fitsfile'),
 #                                                dtype=('i8', dummyreflabel.t['reflabel'].dtype, 'S40',
                                                 dtype=('i8', np.dtype(object), np.dtype(object),
                                                        self.imtable.t['imtype'].dtype,
                                                        self.imtable.t['DETECTOR'].dtype,
-                                                       np.dtype(object),
+                                                       np.dtype(object), np.dtype(object),
                                                        'i8', 'i8', 'f8', self.imtable.t['fitsfile'].dtype))
         self.inputimagestable.t['cmdID', 'imindex', 'imID'].format = '%5d'
         self.inputimagestable.t['MJD'].format = '%.8f'
@@ -1165,7 +1245,8 @@ class mkrefsclass(astrotableclass):
 
                         dict2add = {'cmdID': cmdID, 'imindex': imindex, 'reflabel': reflabel,
                                     'detector': detector, 'imlabel': inputimagelabel,
-                                    'ssbsteps': self.cfg.params[reflabel]['ssbsteps']}
+                                    'ssbsteps': self.cfg.params[reflabel]['ssbsteps'],
+                                    'ssb_save_steps': self.cfg.params[reflabel]['ssb_save_steps']}
                         for key in ['fitsfile', 'imID', 'imtype', 'MJD']:
                             dict2add[key] = self.imtable.t[key][imindex]
                         self.inputimagestable.t.add_row(dict2add)
@@ -1187,24 +1268,26 @@ class mkrefsclass(astrotableclass):
         print('**** ADD: additional check if input images are the same!! ****')
         self.inputimagestable.write('%s.inputim.txt' % self.basename, verbose=True, clobber=True)
 
-        mmm = CalibPrep(self.cfg.params['instrument'])
-        mmm.inputs = self.inputimagestable.t
+        print('Before calib_prep:')
+        print(self.inputimagestable.t)
 
-        print('Bryan: we need to look for ssb files in the ssb output dir, and then also in the optional pipeline_prod_search_dir. Let me know how I should pass this inof!')
-        mmm.search_dir = self.ssbdir
+        calib = CalibPrep(self.cfg.params['instrument'])
+        calib.inputs = self.inputimagestable.t
+
+        calib.search_dir = self.ssbdir
         # add additional search dirs!
         if self.cfg.params['output']['pipeline_prod_search_dir'] is not None:
-            mmm.search_dir += ',%s' % (self.cfg.params['output']['pipeline_prod_search_dir'])
+            calib.search_dir = [self.ssbdir, self.cfg.params['output']['pipeline_prod_search_dir']]
 
-        mmm.output_dir = self.ssbdir
-        mmm.prepare()
+        calib.output_dir = self.ssbdir
+        calib.prepare()
 
+        #print('\n\n')
         #print('BACK IN MKREFS:')
-        # print(mmm.proc_table['index', 'cmdID', 'reflabel', 'steps_to_run', 'repeat_of_index_number', 'index_contained_within'])
-        #print(mmm.proc_table['strun_command'][-1])
+        #print(calib.proc_table['index', 'cmdID', 'reflabel', 'steps_to_run', 'ssb_save_steps', 'repeat_of_index_number', 'index_contained_within'])
 
         self.ssbcmdtable.verbose = self.verbose
-        self.ssbcmdtable.t = mmm.proc_table
+        self.ssbcmdtable.t = calib.proc_table
 
         # check which entries are primary strun commands. Only primary
         # strun commands need to be executed, secondary strun commands
@@ -1238,7 +1321,7 @@ class mkrefsclass(astrotableclass):
         #                                    'already_in_batch', 'execute_strun', 'strun_executed'])
 
         #print('strun commands:')
-        #print(mmm.strun)
+        #print(calib.strun)
         print(self.ssbcmdtable.t['index', 'real_input_file', 'ssbsteps', 'repeat_of_index_number',
                                  'index_contained_within', 'primary_strun', 'file_already_exists',
                                  'already_in_batch', 'execute_strun', 'strun_executed'])

--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -12,7 +12,6 @@ from logging.handlers import RotatingFileHandler
 
 import astropy.io.fits as fits
 from astropy.io import ascii
-from astropy.table import vstack
 import astropy
 import numpy as np
 import scipy
@@ -824,15 +823,13 @@ class mkrefsclass(astrotableclass):
         D.t['D1index'] = dindex4detector
         D.t['D1imID'] = self.imtable.t['imID'][dindex4detector]
         D.t['D1index', 'D1imID'].format = '%d'
-        #print D.t
-        #sys.exit(0)
         return(D, ('D1',))
 
     def getDDlist(self, detector, max_Delta_MJD=None):
         '''
         returns list of Dark-Dark pair indeces,  where the indices refer to the self.imtable table
         '''
-        #logger.debug('# Getting DD list')
+        self.logger.debug('# Getting DD list')
         #self.imtable.t['skip'][7]=True
         #print  self.imtable.t[6:11]
 
@@ -841,33 +838,32 @@ class mkrefsclass(astrotableclass):
         # indices for detector and not skipped
         dindex4detector = dindex[np.where(np.logical_and(self.imtable.t['DETECTOR'][dindex] == detector,
                                                          np.logical_not(self.imtable.t['skip'][dindex])))]
-        #logger.info('Possible %d Darks for detector %s' % (len(dindex4detector), detector))
-        #logger.info(self.imtable.t[dindex4detector])
+        self.logger.info('Possible %d Darks for detector %s' % (len(dindex4detector), detector))
+        self.logger.info(self.imtable.t[dindex4detector])
 
         DD = astrotableclass(names=('D1index', 'D2index', 'D1imID', 'D2imID'), dtype=('i4', 'i4', 'i4', 'i4'))
         i = 0
         while i < len(dindex4detector)-1:
             if max_Delta_MJD is not None:
-                #logger.info('Checking if imID={} and {} can be DD'.format(self.imtable.t['imID'][dindex4detector[i]],
-                #                                                           self.imtable.t['imID'][dindex4detector[i+1]]))
+                self.logger.info('Checking if imID={} and {} can be DD'.format(self.imtable.t['imID'][dindex4detector[i]],
+                                                                               self.imtable.t['imID'][dindex4detector[i+1]]))
                 dMJD = self.imtable.t['MJD'][dindex4detector[i+1]]-self.imtable.t['MJD'][dindex4detector[i]]
-                #logger.debug('dMJD:', dMJD)
+                self.logger.debug('dMJD:', dMJD)
                 if dMJD > max_Delta_MJD:
-                    #logger.info(('Skipping imID={} (MJD={}) since imID={} is not within timelimit (Delta '
-                    #              'MJD = {}>{})!'.format(self.imtable.t['imID'][dindex4detector[i]],
-                    #                                     self.imtable.t['MJD'][i],
-                    #                                     self.imtable.t['imID'][dindex4detector[i+1]],
-                    #                                     dMJD, max_Delta_MJD)))
+                    self.logger.info(('Skipping imID={} (MJD={}) since imID={} is not within timelimit (Delta '
+                                      'MJD = {}>{})!'.format(self.imtable.t['imID'][dindex4detector[i]],
+                                                             self.imtable.t['MJD'][i],
+                                                             self.imtable.t['imID'][dindex4detector[i+1]],
+                                                             dMJD, max_Delta_MJD)))
                     i += 1
                     continue
-            #logger.info('Adding DD pair with imID={} and {}'.format(self.imtable.t['imID'][dindex4detector[i]],
-            #                                                         self.imtable.t['imID'][dindex4detector[i+1]]))
+            self.logger.info('Adding DD pair with imID={} and {}'.format(self.imtable.t['imID'][dindex4detector[i]],
+                                                                         self.imtable.t['imID'][dindex4detector[i+1]]))
             DD.t.add_row({'D1index': dindex4detector[i], 'D2index': dindex4detector[i+1],
                           'D1imID': self.imtable.t['imID'][dindex4detector[i]],
                           'D2imID': self.imtable.t['imID'][dindex4detector[i+1]]})
             i += 2
 
-        #logger.debug(DD.t)
         return(DD, ('D1', 'D2'))
 
     def getDpluslist(self, detector, max_Delta_MJD=None):
@@ -1025,40 +1021,39 @@ class mkrefsclass(astrotableclass):
         '''
         returns list of Flat-Flat pair indeces, where the indices refer to the self.imtable table
         '''
-        #self.logger.info('# Getting FF list')
+        self.logger.info('# Getting FF list')
 
         # indices for dark frames
         findex, = np.where(self.imtable.t['imtype'] == 'flat')
         # indices for detector and not skipped
         findex4detector = findex[np.where(np.logical_and(self.imtable.t['DETECTOR'][findex] == detector,
                                                          np.logical_not(self.imtable.t['skip'][findex])))]
-        #self.logger.info('Possible {} Flats for detector {}'.format(len(findex4detector), detector))
-        #self.logger.info(self.imtable.t[findex4detector])
+        self.logger.info('Possible {} Flats for detector {}'.format(len(findex4detector), detector))
+        self.logger.info(self.imtable.t[findex4detector])
 
         FF = astrotableclass(names=('F1index', 'F2index', 'F1imID', 'F2imID'), dtype=('i4', 'i4', 'i4', 'i4'))
         i = 0
         while i < len(findex4detector)-1:
             if max_Delta_MJD is not None:
-                #self.logger.info('Checking if imID={} and {} can be FF'.format(self.imtable.t['imID'][findex4detector[i]],
-                #                                                           self.imtable.t['imID'][findex4detector[i+1]]))
+                self.logger.info('Checking if imID={} and {} can be FF'.format(self.imtable.t['imID'][findex4detector[i]],
+                                                                               self.imtable.t['imID'][findex4detector[i+1]]))
                 dMJD = self.imtable.t['MJD'][findex4detector[i+1]]-self.imtable.t['MJD'][findex4detector[i]]
-                #self.logger.debug('dMJD:', dMJD)
+                self.logger.debug('dMJD:', dMJD)
                 if dMJD > max_Delta_MJD:
-                    #self.logger.info(('Skipping imID={} (MJD={}) since imID={} is not within '
-                    #              'timelimit (Delta MJD = {}>{})!').format(self.imtable.t['imID'][findex4detector[i]],
-                    #                                                       self.imtable.t['MJD'][i],
-                    #                                                       self.imtable.t['imID'][findex4detector[i+1]],
-                    #                                                       dMJD, max_Delta_MJD))
+                    self.logger.info(('Skipping imID={} (MJD={}) since imID={} is not within '
+                                      'timelimit (Delta MJD = {}>{})!').format(self.imtable.t['imID'][findex4detector[i]],
+                                                                               self.imtable.t['MJD'][i],
+                                                                               self.imtable.t['imID'][findex4detector[i+1]],
+                                                                               dMJD, max_Delta_MJD))
                     i += 1
                     continue
-            #self.logger.info('Adding FF pair with imID={} and {}'.format(self.imtable.t['imID'][findex4detector[i]],
-            #                                                         self.imtable.t['imID'][findex4detector[i+1]]))
+            self.logger.info('Adding FF pair with imID={} and {}'.format(self.imtable.t['imID'][findex4detector[i]],
+                                                                         self.imtable.t['imID'][findex4detector[i+1]]))
             FF.t.add_row({'F1index': findex4detector[i], 'F2index': findex4detector[i+1],
                           'F1imID': self.imtable.t['imID'][findex4detector[i]],
                           'F2imID': self.imtable.t['imID'][findex4detector[i+1]]})
             i += 2
 
-        #self.logger.debug(FF.t)
         return(FF, ('F1', 'F2'))
 
     def getDDFFlist(self, detector, DD_max_Delta_MJD=None, FF_max_Delta_MJD=None, DDFF_max_Delta_MJD=None):

--- a/jwst_reffiles/mkrefs.py
+++ b/jwst_reffiles/mkrefs.py
@@ -31,8 +31,6 @@ from jwst_reffiles.utils.tools import makepath, executecommand, append2file, rmf
 #                     '%s/badpix_map' % rootdir])
 #else:
 #rootdir = os.path.dirname(os.path.realpath(__file__))
-
-
 class cmdsclass(astrotableclass):
     def __init__(self, cmdtype, *args, verbose=0, debug=False, manual_log=None, **kwargs):
         #self.loginfo.append(('info', "Creating cmdsclass instance with cmdtype {}".format(cmdtype)))

--- a/jwst_reffiles/pipeline/calib_prep.py
+++ b/jwst_reffiles/pipeline/calib_prep.py
@@ -116,10 +116,10 @@ class CalibPrep:
         self.output_dir = ''
         #self.pipe_step_dict = OrderedDict(PIPE_STEPS)
 
-        instrument = instrument.lower()
-        if instrument not in INSTRUMENTS:
-            raise ValueError("WARNING: {} is not a valid instrument name.".format(instrument))
-        self.pipe_step_list = get_pipeline_steps(instrument)
+        self.instrument = instrument.lower()
+        if self.instrument not in INSTRUMENTS:
+            raise ValueError("WARNING: {} is not a valid instrument name.".format(self.instrument))
+        self.pipe_step_list = get_pipeline_steps(self.instrument)
 
     def activate_encompassing_entries(self):
         """Once the search for ssb commands contained within other ssb commands has
@@ -310,16 +310,30 @@ class CalibPrep:
 
                 self.logger.debug('matching rows:{}'.format(matching_rows))
 
-                # Strip all whitespace from the list of ssb steps. Use this as
-                # a comparison to see if there are repeats among those with matching
+                # Strip all whitespace from the list of ssb steps and the list of
+                # intermediate pipeline outputs to be saved. Use these as
+                # comparisons to see if there are repeats among those with matching
                 # filenames.
                 row_ssb = re.sub(r'\s+', '', row['steps_to_run'])
+                if row['ssb_save_steps'] is not None:
+                    row_ssb_save = [elem.strip() for elem in row['ssb_save_steps'].split(',')]
+                else:
+                    row_ssb_save = []
                 outname = row['output_name']
                 for matching_row in matching_rows:
                     ssbsteps = re.sub(r'\s+', '', matching_row['steps_to_run'])
+                    if matching_row['ssb_save_steps'] is not None:
+                        ssbsavesteps = [elem.strip() for elem in matching_row['ssb_save_steps'].split(',')]
+                        # Check to see if the requested list of steps where output
+                        # files are needed is contained within the list of output
+                        # steps in the comparison row
+                        inside = [True if comp in row_ssb_save else False for comp in ssbsavesteps]
+                    else:
+                        ssbsavesteps = []
+                        inside = [True]
                     row_index = matching_row['index']
 
-                    if ssbsteps in row_ssb:
+                    if ssbsteps in row_ssb and all(inside):
                         # If the list of ssb steps is contained within the list of
                         # steps from the comparison file, then this entry is duplicate.
                         # Save the output name from this row if it is different from the
@@ -398,7 +412,7 @@ class CalibPrep:
         """
         full_filename = os.path.join(self.output_dir, filename)
         if not os.path.isfile(full_filename):
-            print('INFO: {} file does not exist in {}. Creating.'.format(filename,
+            self.logger.info('INFO: {} file does not exist in {}. Creating.'.format(filename,
                                                                          self.output_dir))
             cfg_reference = os.path.join(os.path.dirname(__file__), 'config_files/{}'.format(filename))
             if not testing:
@@ -615,15 +629,17 @@ class CalibPrep:
         self.strun = []
         realinput = []
         all_to_run = []
+        all_to_save = []
 
         # Create generators of files in self.search_dir, to be searched later for
         # matching filenames
         self.search_dir_decompose()
         search_generator = self.build_search_generator()
 
+        # Loop over rows of the input table and get information that will be
+        # used to construct strun calls.
         for line in self.inputs:
             file = line['fitsfile']
-
             req_steps = self.step_dict(line['ssbsteps'])
 
             self.logger.info("File: {}".format(file))
@@ -656,8 +672,7 @@ class CalibPrep:
             if not self.use_only_given:
                 # for now I replace this with glob. BRYAN: PLEASE CHECK THIS!
                 #files = self.file_search(true_base, search_generator)
-                tmpdummydir = '%s/%s*fits'% (self.search_dir,true_base)
-                print('Looking into tmpdummydir:',tmpdummydir)
+                tmpdummydir = os.path.join(self.search_dir, '{}*fits'.format(true_base))
                 files = glob(tmpdummydir)
             else:
                 files = [os.path.join(self.search_dir, file)]
@@ -706,6 +721,13 @@ class CalibPrep:
 
             self.logger.info("Steps that need to be run: {}".format(to_run))
 
+            # Keep track of the pipeline steps whose output needs to be saved
+            if line['ssb_save_steps'] is not None:
+                row_save_steps = re.sub(r'\s+', '', line['ssb_save_steps'])
+            else:
+                row_save_steps = ''
+            all_to_save.append(row_save_steps)
+
         # Add the output filename column to the input table
         realcol = Column(data=realinput, name='real_input_file')
         self.inputs.add_column(realcol)
@@ -713,6 +735,8 @@ class CalibPrep:
         self.inputs.add_column(outcol)
         toruncol = Column(all_to_run, name='steps_to_run')
         self.inputs.add_column(toruncol)
+        tosavecol = Column(all_to_save, name='steps_to_save')
+        self.inputs.add_column(tosavecol)
 
         # Add an overall index column (to be used as a reference when flagging
         # repeated rows)
@@ -720,7 +744,7 @@ class CalibPrep:
         self.inputs.add_column(indexcol, index=0)
 
         # Turn the table into a series of strun commands
-        self.strun = self.strun_command(realcol, toruncol, outcol)  # ,reffiles=??)
+        self.strun = self.strun_command(realcol, toruncol, outcol, tosavecol)  # ,reffiles=??)
 
         # Add the list of strun commands to the input table
         cmds = Column(data=self.strun, name='strun_command')
@@ -771,7 +795,7 @@ class CalibPrep:
         stepslist = [element.strip() for element in stepstr.split(',')]
         for ele in stepslist:
             if ele not in self.pipe_step_list:
-                self.logging.error(("WARNING: unrecognized pipeline step: {}"
+                self.logger.error(("WARNING: unrecognized pipeline step: {}"
                                     .format(ele)))
                 raise ValueError(("WARNING: unrecognized pipeline step: {}"
                                   .format(ele)))
@@ -818,8 +842,8 @@ class CalibPrep:
                                      "be. Need a new input file.".format(infile, key)))
         return torun
 
-    def strun_command(self, input_files, steps_to_run, outfile_name, overrides=[], instrument='nircam',
-                      testing=False):
+    def strun_command(self, input_files, steps_to_run, outfile_name, steps_to_save, overrides=[],
+                      instrument='nircam', testing=False):
         '''Create the necessary strun command to run the
         appropriate JWST calibration pipeline steps
 
@@ -834,6 +858,10 @@ class CalibPrep:
 
         outfile_name : astropy.table.Column
             astropy table column object listing pipeline ouput fits file name
+
+        steps_to_save : astropy.table.Column
+            astropy table column object giving a comma-separated list of pipeline
+            steps whose output should be saved
 
         instrument : str
             Name of instrument. Used to collect the appropriate pipeline steps
@@ -873,7 +901,7 @@ class CalibPrep:
 
         # Create the strun command
         initial = 'strun {} '.format(pipeline_cfg_file)
-        for infile, steps, outfile in zip(input_files, steps_to_run, outfile_name):
+        for infile, steps, outfile, save_steps in zip(input_files, steps_to_run, outfile_name, steps_to_save):
             with_file = initial + infile
 
             if steps == 'None':
@@ -881,14 +909,41 @@ class CalibPrep:
             else:
                 skip_text = ''
                 out_text = ''
+                save_text = ''
                 for key in step_names:
 
                     # Add skip statements for the steps to be skipped
                     if key not in steps:
                         skip_text += ' --steps.{}.skip=True'.format(step_names[key])
 
+                    # Save outputs from requested steps
+                    if key in save_steps:
+                        save_text += ' --steps.{}.save_results=True'.format(step_names[key])
+
                     # Add override reference files
-                    print("Add ability to override reference files here")
+                    # print("Add ability to override reference files here")
+
+                # Generate the output names for any intermediate output products
+                save_steps_list = [elem.strip() for elem in save_steps.split(',')]
+                for stepname in save_steps_list:
+
+                    # Get a list of steps to be done up to stepname
+                    step_loc = steps.find(stepname)
+                    if step_loc != -1:
+                        tmp_list = steps[0: step_loc + len(stepname)]
+
+                        tmp_dict = self.step_dict(tmp_list)
+                        tmp_basename = self.get_file_basename(infile)
+
+                        # Generate the output name expected for these steps, and
+                        # add to the strun command
+                        tmp_outname, true_base = self.create_output(tmp_basename, tmp_dict)
+                        save_text += ' --steps.{}.output_file={}'.format(stepname, tmp_outname)
+
+                # If the optional "fitopt" ramp-fitting product is requested, add that
+                # to the strun command
+                if 'fitopt' in save_steps:
+                    save_text += ' --steps.ramp_fit.save_opt=True'
 
                 # Get the suffix from the difference between the input and output names
                 infile_base = os.path.split(infile)[1]
@@ -915,8 +970,8 @@ class CalibPrep:
                 # does not strip off any suffix pieces.
                 if outfile_base[-11:] == '_0_ramp_fit':
                     outfile_base = outfile_base.replace('_0_ramp_fit', '')
-                    final_suffix = outfile_base.split('_')[-1]
-                    outfile_base = outfile_base + '_{}'.format(final_suffix)
+                    #final_suffix = outfile_base.split('_')[-1]
+                    #outfile_base = outfile_base + '_{}'.format(final_suffix)
 
                 # Add step-specific options for saving
                 finstep = steps.split(',')[-1]
@@ -930,7 +985,7 @@ class CalibPrep:
                 out_dir = ' --output_dir={}'.format(self.output_dir)
 
                 # Put the whole command together
-                cmd = with_file + skip_text + out_text + out_dir
+                cmd = with_file + skip_text + out_text + out_dir + save_text
 
                 # Since we are getting the output from the final step directly
                 # we can turn off the output from the pipeline

--- a/jwst_reffiles/pipeline/calib_prep.py
+++ b/jwst_reffiles/pipeline/calib_prep.py
@@ -744,7 +744,7 @@ class CalibPrep:
         self.inputs.add_column(indexcol, index=0)
 
         # Turn the table into a series of strun commands
-        self.strun = self.strun_command(realcol, toruncol, outcol, tosavecol)  # ,reffiles=??)
+        self.strun = self.strun_command(realcol, toruncol, outcol, tosavecol)
 
         # Add the list of strun commands to the input table
         cmds = Column(data=self.strun, name='strun_command')

--- a/tests/test_calib_prep.py
+++ b/tests/test_calib_prep.py
@@ -155,28 +155,37 @@ def strun_command_test(cp_object):
     torun1 = 'saturation,superbias,dark_current,jump'
     torun2 = 'dq_init,superbias,refpix'
     torun3 = 'dark_current,linearity,rate'
+    tosave1 = 'superbias,dark_current'
+    tosave2 = 'dq_init'
+    tosave3 = 'linearity'
     steps_to_run = Column(data=[torun1, torun2, torun3])
+    steps_to_save = Column(data=[tosave1, tosave2, tosave3])
     out_names = ['dummy_sat_superbias_dark_jump', 'dummy_dq_init_superbias_refpix',
                  'dummy_dark_linearity_rate']
     suffixes = ['sat_superbias_dark_jump', 'dq_init_superbias_refpix', 'dark_linearity_rate']
     output_filename = Column(data=out_names)
-    constructed_commands = cp_object.strun_command(input_names, steps_to_run, output_filename, testing=True)
+    constructed_commands = cp_object.strun_command(input_names, steps_to_run, output_filename, steps_to_save, testing=True)
     pipeline_cfg_file = os.path.join(cp_object.output_dir, 'calwebb_detector1.cfg')
     truth1 = ('strun {} {} --steps.group_scale.skip=True --steps.dq_init.skip=True --steps.ipc.skip=True '
               '--steps.refpix.skip=True --steps.linearity.skip=True --steps.persistence.skip=True '
               '--steps.ramp_fit.skip=True --steps.jump.output_file={} --steps.jump.save_results=True '
-              '--output_dir={} --save_results=False --steps.jump.rejection_threshold=100 --steps.refpix.odd_even_rows=False'
+              '--output_dir={} --steps.superbias.save_results=True --steps.dark_current.save_results=True '
+              '--steps.superbias.output_file=/dummy/output/dir/dummy_saturation_superbias.fits '
+              '--steps.dark_current.output_file=/dummy/output/dir/dummy_saturation_superbias_dark_current.fits '
+              '--save_results=False --steps.jump.rejection_threshold=100 --steps.refpix.odd_even_rows=False'
               .format(pipeline_cfg_file, in_names[0], out_names[0], cp_object.output_dir))
     truth2 = ('strun {} {} --steps.group_scale.skip=True --steps.saturation.skip=True --steps.ipc.skip=True '
               '--steps.linearity.skip=True --steps.persistence.skip=True --steps.dark_current.skip=True '
               '--steps.jump.skip=True --steps.ramp_fit.skip=True --steps.refpix.output_file={} '
-              '--steps.refpix.save_results=True --output_dir={} --save_results=False '
+              '--steps.refpix.save_results=True --output_dir={} --steps.dq_init.save_results=True '
+              '--steps.dq_init.output_file=/dummy/output/dir/dummy_dq_init.fits --save_results=False '
               '--steps.jump.rejection_threshold=100 --steps.refpix.odd_even_rows=False'
               .format(pipeline_cfg_file, in_names[1], out_names[1], cp_object.output_dir))
     truth3 = ('strun {} {} --steps.group_scale.skip=True --steps.dq_init.skip=True --steps.saturation.skip=True '
               '--steps.ipc.skip=True --steps.superbias.skip=True --steps.refpix.skip=True '
               '--steps.persistence.skip=True --steps.jump.skip=True --steps.ramp_fit.output_file={} '
-              '--steps.ramp_fit.save_results=True --output_dir={} --save_results=False '
+              '--steps.ramp_fit.save_results=True --output_dir={} --steps.linearity.save_results=True '
+              '--steps.linearity.output_file=/dummy/output/dir/dummy_linearity_dark_current.fits --save_results=False '
               '--steps.jump.rejection_threshold=100 --steps.refpix.odd_even_rows=False'
               .format(pipeline_cfg_file, in_names[2], out_names[2], cp_object.output_dir))
     truths = [truth1, truth2, truth3]
@@ -184,8 +193,12 @@ def strun_command_test(cp_object):
 
     print('')
     print(constructed_commands[0])
+    print(constructed_commands[1])
+    print(constructed_commands[2])
     print('')
     print(truth1)
+    print(truth2)
+    print(truth3)
     print('')
 
 


### PR DESCRIPTION
This PR integrates bad_pixel_mask.py into the mkrefs framework. This includes the creation of the mkrefs_bad_pixel_mask.py file, which is how mkrefs.py calls bad_pixel_mask.py. Several updates to mkrefs.py and calib_prep.py also had to be made to get the integration working.


- The bad pixel mask generator needs a collection of flats and a collection of darks, so users can now specify 'D+F+', 'F+D+', 'FD+', or 'DF+' when describing the files needed. mkrefs then returns the full list of input darks and flats.
- The bad pixel mask generator uses several versions of each input file, in several states of calibration. As a result, calib_prep.py was modified to be able to save the results of intermediate pipeline steps. This was accomplished by adding a new column to the input file table. This column lists the pipeline steps whose outputs should be saved. The data table column is populated via the new `ssb_save_steps` entry in the mkrefs.cfg file.

