### PR TITLE
Add placeholder for future CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,1 @@
+# placeholder


### PR DESCRIPTION
Adding a placeholder so that when the real `ci.yml` is added, the Github action will actually run.