### PR TITLE
Fix typo in package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     ],
     packages=find_packages(),
     include_package_data=True,
-    package_data={'jwst_reffiles': ['bad_pixel_masks/*.txt']
+    package_data={'jwst_reffiles': ['bad_pixel_mask/*.txt']
                   },
     scripts=["jwst_reffiles/mkrefs.py"],
     install_requires=[


### PR DESCRIPTION
The misspelled subdirectory name was preventing the package data files from being installed.