### PR TITLE
Fix bug in addition of badpix from dark and badpix from flat

### DIFF
--- a/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
+++ b/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
@@ -426,7 +426,7 @@ def bad_pixels(flat_slope_files=None, dead_search=True, low_qe_and_open_search=T
         hdu.header[bad_from_dark_kw] = False
 
     # Combine the two masks
-    final_mask = flatmask + darkmask
+    final_mask = np.bitwise_or(flatmask, darkmask)
 
     # Save mask in reference file
     hdu_list = fits.HDUList([hdu])

--- a/jwst_reffiles/bad_pixel_mask/badpix_from_flats.py
+++ b/jwst_reffiles/bad_pixel_mask/badpix_from_flats.py
@@ -365,11 +365,6 @@ def combine_individual_maps(bad_maps, do_not_use_flags):
     # The official bit definitions for bad pixel flavors
     dq_defs = dqflags.pixel
 
-    # Temporary fix to get around pipeline bug (which will be fixed in
-    # the next release)
-    dq_defs['REFERENCE_PIXEL'] = 128
-    dq_defs['RESERVED_4'] = 2147483648
-
     # Convert each type of bad pixel input to have the proper value,
     # and add to the final map
     do_not_use_map = np.zeros((bad_maps['DEAD'].shape)).astype(np.int)


### PR DESCRIPTION
Previously in bad_pixel_mask, the addition of the bad pixel mask from the dark current files and the bad pixel mask from the flat field files was a simple array addition. 

This PR fixes that bug and changes that into a bitwise or addition.