### PR TITLE
create_history_entry now in stdatamodels

### DIFF
--- a/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
+++ b/jwst_reffiles/bad_pixel_mask/bad_pixel_mask.py
@@ -8,7 +8,8 @@ import datetime
 import os
 
 from astropy.io import fits
-from jwst.datamodels import MaskModel, util
+from jwst.datamodels import MaskModel
+from stdatamodels import util
 import numpy as np
 
 from jwst_reffiles.bad_pixel_mask import badpix_from_flats

--- a/jwst_reffiles/bad_pixel_mask/badpix_from_flats.py
+++ b/jwst_reffiles/bad_pixel_mask/badpix_from_flats.py
@@ -61,8 +61,9 @@ from astropy.convolution import convolve, Box2DKernel
 from astropy.io import fits, ascii
 from astropy.stats import sigma_clip
 from scipy.ndimage import median_filter
-from jwst.datamodels import dqflags, util, MaskModel, Level1bModel
+from jwst.datamodels import dqflags, MaskModel, Level1bModel
 from jwst.dq_init import DQInitStep
+from stdatamodels import util
 
 
 def find_bad_pix(input_files, dead_search=True, low_qe_and_open_search=True, dead_search_type='sigma_rate',

--- a/jwst_reffiles/readnoise/readnoise.py
+++ b/jwst_reffiles/readnoise/readnoise.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-"""This module creates a readnoise reference file that can be used 
+"""This module creates a readnoise reference file that can be used
 in the JWST calibration pipeline.
 
 Author
@@ -21,11 +21,11 @@ Notes
 
     Algorithm:
 
-    Method 1 (method='stack'): 
-    Create CDS images for each input ramp. Stack all of these 
-    images from each input ramp together. The readnoise is the sigma-clipped 
+    Method 1 (method='stack'):
+    Create CDS images for each input ramp. Stack all of these
+    images from each input ramp together. The readnoise is the sigma-clipped
     standard deviation through this master CDS image stack.
-    
+
     Method 2 (method='ramp'):
     Calculate the readnoise in each ramp individually, and then average
     these readnoise images together to produce a final readnoise map.
@@ -36,7 +36,8 @@ import os
 
 from astropy.io import fits
 from astropy.stats import sigma_clip
-from jwst.datamodels import ReadnoiseModel, util
+from jwst.datamodels import ReadnoiseModel
+from stdatamodels import util
 import numpy as np
 
 def calculate_mean(stack, clipping_sigma=3.0, max_clipping_iters=3):
@@ -46,12 +47,12 @@ def calculate_mean(stack, clipping_sigma=3.0, max_clipping_iters=3):
     ----------
     stack : numpy.ndarray
         A 3D stack of images.
-    
+
     clipping_sigma : float
         Number of sigmas to use when sigma-clipping the input stack.
 
     max_clipping_iters : int
-        Maximum number of iterations to use when sigma-clipping the input 
+        Maximum number of iterations to use when sigma-clipping the input
         stack.
 
     Returns
@@ -60,7 +61,7 @@ def calculate_mean(stack, clipping_sigma=3.0, max_clipping_iters=3):
         2D image of the sigma-clipped mean through the input stack.
     """
 
-    clipped = sigma_clip(stack, sigma=clipping_sigma, 
+    clipped = sigma_clip(stack, sigma=clipping_sigma,
                          maxiters=max_clipping_iters, axis=0)
     mean_image = np.mean(clipped, axis=0)
 
@@ -74,35 +75,35 @@ def calculate_stddev(stack, clipping_sigma=3.0, max_clipping_iters=3):
     ----------
     stack : numpy.ndarray
         A 3D stack of images.
-    
+
     clipping_sigma : float
         Number of sigmas to use when sigma-clipping the input stack.
 
     max_clipping_iters : int
-        Maximum number of iterations to use when sigma-clipping the input 
+        Maximum number of iterations to use when sigma-clipping the input
         stack.
 
     Returns
     -------
     stddev_image : numpy.ndarray
-        2D image of the sigma-clipped standard deviation through the 
+        2D image of the sigma-clipped standard deviation through the
         input stack.
     """
 
-    clipped = sigma_clip(stack, sigma=clipping_sigma, 
+    clipped = sigma_clip(stack, sigma=clipping_sigma,
                          maxiters=max_clipping_iters, axis=0)
     stddev_image = np.std(clipped, axis=0)
 
     return stddev_image
 
 def get_crds_info(filename, subarray, readpatt):
-    """Get CRDS-required header information to put into the final readnoise 
+    """Get CRDS-required header information to put into the final readnoise
     reference file.
 
     Parameters
     ----------
     filename : str
-        Path to one of the files being used to generate the readnoise 
+        Path to one of the files being used to generate the readnoise
         reference file. Will be used to find default values.
 
     subarray : str
@@ -127,7 +128,7 @@ def get_crds_info(filename, subarray, readpatt):
 
     fastaxis : int
         CRDS-required fastaxis of the reference file.
-    
+
     slowaxis : int
         CRDS-required slowaxis of the reference file.
 
@@ -155,20 +156,20 @@ def get_crds_info(filename, subarray, readpatt):
 
 
 def make_cds_stack(data, group_diff_type='independent'):
-    """Creates a stack of CDS images (group difference images) using the 
+    """Creates a stack of CDS images (group difference images) using the
     input ramp data, combining multiple integrations if necessary.
 
     Parameters
     ----------
     data : numpy.ndarray
-        The input ramp data. The data shape is assumed to be a 4D array in 
+        The input ramp data. The data shape is assumed to be a 4D array in
         DMS format (integration, group, y, x).
-    
+
     group_diff_type : str
         The method for calculating group differences. Options are:
-        ``independent``: Each group is only differenced once (e.g. 6-5, 4-3, 
+        ``independent``: Each group is only differenced once (e.g. 6-5, 4-3,
                          2-1)
-        ``consecutive``: Each group is differenced to its neighbors (e.g. 
+        ``consecutive``: Each group is differenced to its neighbors (e.g.
                          4-3, 3-2, 2-1)
 
     Returns
@@ -193,38 +194,38 @@ def make_cds_stack(data, group_diff_type='independent'):
 
     return cds_stack
 
-def make_readnoise(filenames, method='stack', group_diff_type='independent', 
-                   clipping_sigma=3.0, max_clipping_iters=3, nproc=1, 
-                   slice_width=50, single_value=False, 
-                   outfile='readnoise_jwst_reffiles.fits', 
-                   author='jwst_reffiles', description='CDS Noise Image', 
-                   pedigree='GROUND', useafter='2015-10-01T00:00:00', 
+def make_readnoise(filenames, method='stack', group_diff_type='independent',
+                   clipping_sigma=3.0, max_clipping_iters=3, nproc=1,
+                   slice_width=50, single_value=False,
+                   outfile='readnoise_jwst_reffiles.fits',
+                   author='jwst_reffiles', description='CDS Noise Image',
+                   pedigree='GROUND', useafter='2015-10-01T00:00:00',
                    history='', subarray=None, readpatt=None, save_tmp=False):
-    """The main function. Creates a readnoise reference file using the input 
+    """The main function. Creates a readnoise reference file using the input
     dark current ramps. See module docstring for more details.
-    
+
     Parameters
     ----------
     filenames : list
-        List of dark current files. These should be calibrated ramp images. 
-        The data shape in these images is assumed to be a 4D array in DMS 
+        List of dark current files. These should be calibrated ramp images.
+        The data shape in these images is assumed to be a 4D array in DMS
         format (integration, group, y, x).
 
     method : str
         The method to use when calculating the readnoise. Options are:
-        ``stack``: Creates a master stack of all CDS images by combining the 
-                   CDS images for each ramp and integration together. The 
-                   final readnoise map is calculated by taking the stddev 
+        ``stack``: Creates a master stack of all CDS images by combining the
+                   CDS images for each ramp and integration together. The
+                   final readnoise map is calculated by taking the stddev
                    through this master stack.
-        ``ramp``: Calculates the readnoise in each ramp individually. The 
-                  final readnoise map is calculated by averaging these 
+        ``ramp``: Calculates the readnoise in each ramp individually. The
+                  final readnoise map is calculated by averaging these
                   individual readnoise maps together.
 
     group_diff_type : str
         The method for calculating group differences. Options are:
-        ``independent``: Each group is only differenced once (e.g. 6-5, 4-3, 
+        ``independent``: Each group is only differenced once (e.g. 6-5, 4-3,
                          2-1).
-        ``consecutive``: Each group is differenced to its neighbors (e.g. 
+        ``consecutive``: Each group is differenced to its neighbors (e.g.
                          4-3, 3-2, 2-1).
 
     clipping_sigma : float
@@ -237,13 +238,13 @@ def make_readnoise(filenames, method='stack', group_diff_type='independent',
         The number of processes to use during multiprocessing.
 
     slice_width : int
-        The width (in pixels) of the image slice to use during 
-        multiprocessing. The readnoise of each slice is calculated separately 
-        during multiprocessing and combined together at the end of 
+        The width (in pixels) of the image slice to use during
+        multiprocessing. The readnoise of each slice is calculated separately
+        during multiprocessing and combined together at the end of
         processing. Only relevant if method==stack.
 
     single_value : bool
-        Option to use a single readnoise value (the average of all readnoise 
+        Option to use a single readnoise value (the average of all readnoise
         values) for all pixels.
 
     outfile : str
@@ -275,9 +276,9 @@ def make_readnoise(filenames, method='stack', group_diff_type='independent',
         CRDS-required read pattern for which to use this reference file for.
 
     save_tmp : bool
-        Option to save the final readnoise map before turning it into CRDS 
-        format. This is useful if the CRDS transformation fails; in this  
-        scenario, you won't lose all of the final readnoise results so all 
+        Option to save the final readnoise map before turning it into CRDS
+        format. This is useful if the CRDS transformation fails; in this
+        scenario, you won't lose all of the final readnoise results so all
         of the previous processing wasn't for nothing.
     """
 
@@ -296,15 +297,15 @@ def make_readnoise(filenames, method='stack', group_diff_type='independent',
 
     if method == 'stack':
 
-        # Find the column indexes for each image slice to use during 
+        # Find the column indexes for each image slice to use during
         # multiprocessing.
         n_x = fits.getdata(filenames[0], 'SCI').shape[3]
         columns = list(np.arange(n_x)[::slice_width])
         n_cols = len(columns)
 
-        # Find the readnoise by taking the stddev through a master stack of 
-        # CDS images that incorporates every input dark ramp and integration; 
-        # do this in slices to allow for multiprocessing and avoiding memory 
+        # Find the readnoise by taking the stddev through a master stack of
+        # CDS images that incorporates every input dark ramp and integration;
+        # do this in slices to allow for multiprocessing and avoiding memory
         # issues.
         print('Calculating the readnoise in {} separate image slices...'
               .format(n_cols))
@@ -314,8 +315,8 @@ def make_readnoise(filenames, method='stack', group_diff_type='independent',
         sigmas = [clipping_sigma] * n_cols
         iters = [max_clipping_iters] * n_cols
         slice_widths = [slice_width] * n_cols
-        readnoise = p.map(wrapper_readnoise_by_slice, 
-                          zip(files, group_diff_types, sigmas, iters, 
+        readnoise = p.map(wrapper_readnoise_by_slice,
+                          zip(files, group_diff_types, sigmas, iters,
                               columns, slice_widths)
                           )
         readnoise = np.concatenate(readnoise, axis=1)
@@ -333,24 +334,24 @@ def make_readnoise(filenames, method='stack', group_diff_type='independent',
         sigmas = [clipping_sigma] * n_files
         iters = [max_clipping_iters] * n_files
         readnoise_stack = p.map(wrapper_readnoise_by_ramp,
-                                zip(filenames, group_diff_types, sigmas, 
+                                zip(filenames, group_diff_types, sigmas,
                                     iters)
                                 )
         p.close()
         p.join()
 
-        # Create the final readnoise map by averaging the individual  
+        # Create the final readnoise map by averaging the individual
         # readnoise images.
         print('Combining the readnoises for all {} individual ramps '
               'together...'.format(len(filenames)))
-        readnoise = calculate_mean(np.array(readnoise_stack), 
-                                   clipping_sigma=clipping_sigma, 
+        readnoise = calculate_mean(np.array(readnoise_stack),
+                                   clipping_sigma=clipping_sigma,
                                    max_clipping_iters=max_clipping_iters)
 
     else:
         raise ValueError('Unknown readnoise method: {}'.format(method))
 
-    # Convert masked array to normal numpy array and check for any missing 
+    # Convert masked array to normal numpy array and check for any missing
     # data.
     readnoise = readnoise.filled(fill_value=np.nan)
     n_nans = len(readnoise[~np.isfinite(readnoise)])
@@ -360,10 +361,10 @@ def make_readnoise(filenames, method='stack', group_diff_type='independent',
     # Option to use a single readnoise value for all pixels
     if single_value:
         readnoise = use_single_value(readnoise, instrument=instrument,
-                                     detector=detector, subarray=subarray, 
-                                     clipping_sigma=clipping_sigma, 
+                                     detector=detector, subarray=subarray,
+                                     clipping_sigma=clipping_sigma,
                                      max_clipping_iters=max_clipping_iters)
-    
+
     # Save final readnoise map before turning it into CRDS format in case
     # that step has issues (so all of the previous work isnt lost).
     if save_tmp:
@@ -373,11 +374,11 @@ def make_readnoise(filenames, method='stack', group_diff_type='independent',
         print('Creating CRDS-formatted version of {}...'.format(outfile_temp))
 
     # Save the final readnoise reference file in CRDS format
-    save_readnoise(readnoise, instrument=instrument, detector=detector, 
-                   subarray=subarray, readpatt=readpatt, outfile=outfile, 
-                   author=author, description=description, pedigree=pedigree, 
-                   useafter=useafter, history=history, fastaxis=fastaxis, 
-                   slowaxis=slowaxis, substrt1=substrt1, substrt2=substrt2, 
+    save_readnoise(readnoise, instrument=instrument, detector=detector,
+                   subarray=subarray, readpatt=readpatt, outfile=outfile,
+                   author=author, description=description, pedigree=pedigree,
+                   useafter=useafter, history=history, fastaxis=fastaxis,
+                   slowaxis=slowaxis, substrt1=substrt1, substrt2=substrt2,
                    filenames=filenames)
 
 def none_check(value):
@@ -387,7 +388,7 @@ def none_check(value):
     Parameters
     ----------
     value : str or NoneType
-    
+
     Returns
     -------
     new_value : NoneType
@@ -403,21 +404,21 @@ def none_check(value):
 
     return new_value
 
-def readnoise_by_ramp(filename, group_diff_type='independent', 
+def readnoise_by_ramp(filename, group_diff_type='independent',
                       clipping_sigma=3.0, max_clipping_iters=3):
     """Calculates the readnoise for the given input dark current ramp.
-    
+
     Parameters
     ----------
     filename : str
-        The dark current ramp file. The data shape in this image is assumed  
+        The dark current ramp file. The data shape in this image is assumed
         to be a 4D array in DMS format (integration, group, y, x).
 
     group_diff_type : str
         The method for calculating group differences. Options are:
-        ``independent``: Each group is only differenced once (e.g. 6-5, 4-3, 
+        ``independent``: Each group is only differenced once (e.g. 6-5, 4-3,
                          2-1)
-        ``consecutive``: Each group is differenced to its neighbors (e.g. 
+        ``consecutive``: Each group is differenced to its neighbors (e.g.
                          4-3, 3-2, 2-1)
 
     clipping_sigma : float
@@ -429,41 +430,41 @@ def readnoise_by_ramp(filename, group_diff_type='independent',
 
     print('Calculating readnoise for {}'.format(filename))
 
-    # Get the ramp data; remove first 5 groups and last group for MIRI to 
+    # Get the ramp data; remove first 5 groups and last group for MIRI to
     # avoid reset/rscd effects.
     data = fits.getdata(filename, 'SCI', uint=False)
     instrument = fits.getheader(filename)['INSTRUME']
     if instrument == 'MIRI':
         data = data[:, 5:-1, :, :]
 
-    # Create a CDS stack for the input ramp (combining multiple integrations 
+    # Create a CDS stack for the input ramp (combining multiple integrations
     # if necessary).
     cds_stack = make_cds_stack(data, group_diff_type=group_diff_type)
 
     # Calculate the readnoise
-    readnoise = calculate_stddev(cds_stack, clipping_sigma=clipping_sigma, 
+    readnoise = calculate_stddev(cds_stack, clipping_sigma=clipping_sigma,
                                  max_clipping_iters=max_clipping_iters)
 
     return readnoise
 
-def readnoise_by_slice(filenames, group_diff_type='independent', 
+def readnoise_by_slice(filenames, group_diff_type='independent',
                        clipping_sigma=3.0, max_clipping_iters=3, column=0,
                        slice_width=50):
-    """Calculates the readnoise for a given slice in the input dark file 
-    ramps. Useful for multiprocessing and avoiding memory issues for large 
+    """Calculates the readnoise for a given slice in the input dark file
+    ramps. Useful for multiprocessing and avoiding memory issues for large
     image stacks.
 
     Parameters
     ----------
     filenames : list
-        List of dark current files. The data shape in these images is assumed 
+        List of dark current files. The data shape in these images is assumed
         to be a 4D array in DMS format (integration, group, y, x).
 
     group_diff_type : str
         The method for calculating group differences. Options are:
-        ``independent``: Each group is only differenced once (e.g. 6-5, 4-3, 
+        ``independent``: Each group is only differenced once (e.g. 6-5, 4-3,
                          2-1)
-        ``consecutive``: Each group is differenced to its neighbors (e.g. 
+        ``consecutive``: Each group is differenced to its neighbors (e.g.
                          4-3, 3-2, 2-1)
 
     clipping_sigma : float
@@ -484,44 +485,44 @@ def readnoise_by_slice(filenames, group_diff_type='independent',
         2D image of the calculated readnoise.
     """
 
-    print('Calculating readnoise in image slice [{}:{}]'.format(column, 
+    print('Calculating readnoise in image slice [{}:{}]'.format(column,
           column+slice_width))
 
     for i,filename in enumerate(filenames):
 
-        # Get image data for the given slice; if the slice goes outside of 
+        # Get image data for the given slice; if the slice goes outside of
         # the image border, the slice just goes up to the end of the image.
         data = fits.getdata(filename, 'SCI', uint=False)
         data = data[:, :, :, column:column+slice_width]
 
-        # Remove first 5 groups and last group for MIRI to avoid reset/rscd 
+        # Remove first 5 groups and last group for MIRI to avoid reset/rscd
         # effects.
         instrument = fits.getheader(filename)['INSTRUME']
         if instrument == 'MIRI':
             data = data[:, 5:-1, :, :]
 
-        # Create the CDS stack for the image (combining multiple 
-        # integrations if necessary) and add it to the master CDS stack 
+        # Create the CDS stack for the image (combining multiple
+        # integrations if necessary) and add it to the master CDS stack
         # containing the CDS stacks for all images and integrations.
         cds_stack = make_cds_stack(data, group_diff_type=group_diff_type)
         if i == 0:
             master_cds_stack = cds_stack
         else:
-            master_cds_stack = np.concatenate((master_cds_stack, cds_stack), 
+            master_cds_stack = np.concatenate((master_cds_stack, cds_stack),
                                               axis=0)
 
     # Find the readnoise for this column
-    readnoise = calculate_stddev(master_cds_stack, 
-                                 clipping_sigma=clipping_sigma, 
+    readnoise = calculate_stddev(master_cds_stack,
+                                 clipping_sigma=clipping_sigma,
                                  max_clipping_iters=max_clipping_iters)
 
     return readnoise
 
-def save_readnoise(readnoise, instrument='', detector='', subarray='GENERIC', 
+def save_readnoise(readnoise, instrument='', detector='', subarray='GENERIC',
                    readpatt='ANY', outfile='readnoise_jwst_reffiles.fits',
-                   author='jwst_reffiles', description='CDS Noise Image', 
-                   pedigree='GROUND', useafter='2015-10-01T00:00:00', 
-                   history='', fastaxis=-1, slowaxis=2, substrt1=1, substrt2=1, 
+                   author='jwst_reffiles', description='CDS Noise Image',
+                   pedigree='GROUND', useafter='2015-10-01T00:00:00',
+                   history='', fastaxis=-1, slowaxis=2, substrt1=1, substrt2=1,
                    filenames=[]):
     """Saves a CRDS-formatted readnoise reference file.
 
@@ -566,7 +567,7 @@ def save_readnoise(readnoise, instrument='', detector='', subarray='GENERIC',
 
     fastaxis : int
         CRDS-required fastaxis of the reference file.
-    
+
     slowaxis : int
         CRDS-required slowaxis of the reference file.
 
@@ -577,12 +578,12 @@ def save_readnoise(readnoise, instrument='', detector='', subarray='GENERIC',
         CRDS-required starting pixel in axis 2 direction.
 
     filenames : list
-        List of dark current files that were used to generate the reference 
+        List of dark current files that were used to generate the reference
         file.
     """
 
     r = ReadnoiseModel()
-    
+
     r.data = readnoise
     r.meta.bunit_data = 'DN'
     r.meta.instrument.name = instrument
@@ -622,14 +623,14 @@ def save_readnoise(readnoise, instrument='', detector='', subarray='GENERIC',
                 r.history.append(util.create_history_entry(f[val:val+60]))
             else:
                 r.history.append(util.create_history_entry(f[val:]))
-    
+
     if history != '':
         r.history.append(util.create_history_entry(history))
-    
+
     r.save(outfile, overwrite=True)
     print('Final CRDS-formatted readnoise map saved to {}'.format(outfile))
 
-def use_single_value(readnoise, instrument, detector, subarray, 
+def use_single_value(readnoise, instrument, detector, subarray,
                      clipping_sigma=3.0, max_clipping_iters=3):
     """Replaces all readnoise image values with the average of all readnoise
     values.
@@ -657,18 +658,18 @@ def use_single_value(readnoise, instrument, detector, subarray,
     Returns
     -------
     readnoise_single_value : numpy.ndarray
-        2D readnoise image where all of the readnoise values are the same 
+        2D readnoise image where all of the readnoise values are the same
         (the average of all of the original readnoise values).
     """
 
     readnoise_single_value = np.zeros(readnoise.shape)
 
-    # For NIRCam full-frame darks, this option is used to create a readnoise 
-    # reffile to be used for those subarrays without refpix. Therefore, 
-    # only use the readnoise values within the output used to readout the 
-    # subarrays. This is always output 7, i.e. x,y=[0:511,0:2047] in detector 
+    # For NIRCam full-frame darks, this option is used to create a readnoise
+    # reffile to be used for those subarrays without refpix. Therefore,
+    # only use the readnoise values within the output used to readout the
+    # subarrays. This is always output 7, i.e. x,y=[0:511,0:2047] in detector
     # coordinates.
-    if ((instrument == 'NIRCAM') & 
+    if ((instrument == 'NIRCAM') &
         ((subarray == 'FULL') | (subarray == 'GENERIC'))):
         print('Only using Output 7 values to find single readnoise value '
               '(i.e. assuming this readnoise reffile is being used for '
@@ -682,52 +683,52 @@ def use_single_value(readnoise, instrument, detector, subarray,
         else:
             print('Detector {} not recognized - keeping coordinates as is.'
                   .format(detector))
-        
-        # Get only the output 7 values (i.e. x,y=[0:511,0:2047] in detector 
+
+        # Get only the output 7 values (i.e. x,y=[0:511,0:2047] in detector
         # coordinates).
         readnoise, *_ = np.split(readnoise, 4, axis=1)
 
-    # Find the average of all readnoise values, and use it as the single 
+    # Find the average of all readnoise values, and use it as the single
     # readnoise value in the readnoise reffile.
-    clipped = sigma_clip(readnoise, sigma=clipping_sigma, 
+    clipped = sigma_clip(readnoise, sigma=clipping_sigma,
                          maxiters=max_clipping_iters)
     readnoise_single_value[:, :] = np.mean(clipped)
 
     return readnoise_single_value
 
 def wrapper_readnoise_by_ramp(args):
-    """A wrapper around the readnoise_by_ramp function to allow for 
+    """A wrapper around the readnoise_by_ramp function to allow for
     multiprocessing.
-    
+
     Parameters
     ----------
     args : tuple
-        A tuple containing the input arguments for the readnoise_by_ramp 
+        A tuple containing the input arguments for the readnoise_by_ramp
         function. See readnoise_by_ramp docstring for more details.
 
     Returns
     -------
     readnoise : numpy.ndarray
-        2D image of the calculated readnoise (i.e. the output from the 
+        2D image of the calculated readnoise (i.e. the output from the
         readnoise_by_ramp function).
     """
 
     return readnoise_by_ramp(*args)
 
 def wrapper_readnoise_by_slice(args):
-    """A wrapper around the readnoise_by_slice function to allow for 
+    """A wrapper around the readnoise_by_slice function to allow for
     multiprocessing.
-    
+
     Parameters
     ----------
     args : tuple
-        A tuple containing the input arguments for the readnoise_by_slice 
+        A tuple containing the input arguments for the readnoise_by_slice
         function. See readnoise_by_slice docstring for more details.
 
     Returns
     -------
     readnoise : numpy.ndarray
-        2D image of the calculated readnoise (i.e. the output from the 
+        2D image of the calculated readnoise (i.e. the output from the
         readnoise_by_slice function).
     """
 

--- a/jwst_reffiles/superbias/superbias.py
+++ b/jwst_reffiles/superbias/superbias.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-"""This module creates a superbias reference file that can be used 
+"""This module creates a superbias reference file that can be used
 in the JWST calibration pipeline.
 
 Author
@@ -29,7 +29,8 @@ import os
 
 from astropy.io import fits
 from astropy.stats import sigma_clip
-from jwst.datamodels import dqflags, SuperBiasModel, util
+from jwst.datamodels import dqflags, SuperBiasModel
+from stdatamodels import util
 import matplotlib
 matplotlib.use('Agg')
 import matplotlib.pyplot as plt
@@ -43,12 +44,12 @@ def calculate_mean(stack, clipping_sigma=3.0, max_clipping_iters=3):
     ----------
     stack : numpy.ndarray
         A 3D stack of images.
-    
+
     clipping_sigma : float
         Number of sigmas to use when sigma-clipping the input stack.
 
     max_clipping_iters : int
-        Maximum number of iterations to use when sigma-clipping the input 
+        Maximum number of iterations to use when sigma-clipping the input
         stack.
 
     Returns
@@ -57,7 +58,7 @@ def calculate_mean(stack, clipping_sigma=3.0, max_clipping_iters=3):
         2D image of the sigma-clipped mean through the input stack.
     """
 
-    clipped = sigma_clip(stack, sigma=clipping_sigma, 
+    clipped = sigma_clip(stack, sigma=clipping_sigma,
                          maxiters=max_clipping_iters, axis=0)
     mean_image = np.mean(clipped, axis=0)
 
@@ -71,31 +72,31 @@ def calculate_stddev(stack, clipping_sigma=3.0, max_clipping_iters=3):
     ----------
     stack : numpy.ndarray
         A 3D stack of images.
-    
+
     clipping_sigma : float
         Number of sigmas to use when sigma-clipping the input stack.
-    
+
     max_clipping_iters : int
-        Maximum number of iterations to use when sigma-clipping the input 
+        Maximum number of iterations to use when sigma-clipping the input
         stack.
 
     Returns
     -------
     stddev_image : numpy.ndarray
-        2D image of the sigma-clipped standard deviation through the 
+        2D image of the sigma-clipped standard deviation through the
         input stack.
     """
 
-    clipped = sigma_clip(stack, sigma=clipping_sigma, 
+    clipped = sigma_clip(stack, sigma=clipping_sigma,
                          maxiters=max_clipping_iters, axis=0)
     stddev_image = np.std(clipped, axis=0)
 
     return stddev_image
 
-def find_unreliable_bias_pixels(error, bad_clipping_sigma=3.0, 
-                                bad_max_clipping_iters=3, 
+def find_unreliable_bias_pixels(error, bad_clipping_sigma=3.0,
+                                bad_max_clipping_iters=3,
                                 bad_sigma_threshold=5.0, plot=False):
-    """Identifies pixels with high superbias error values (i.e. 
+    """Identifies pixels with high superbias error values (i.e.
     UNRELIABLE_BIAS pixels).
 
     Parameters
@@ -104,25 +105,25 @@ def find_unreliable_bias_pixels(error, bad_clipping_sigma=3.0,
         A 2D superbias error image.
 
     bad_clipping_sigma : float
-        Number of sigma to use when sigma-clipping the superbias error 
+        Number of sigma to use when sigma-clipping the superbias error
         image to find UNRELIABLE_BIAS pixels.
 
     bad_max_clipping_iters : int
-        Maximum number of iterations to use when sigma-clipping the superbias 
+        Maximum number of iterations to use when sigma-clipping the superbias
         error image to find UNRELIABLE_BIAS pixels.
 
     bad_sigma_threshold : float
-        Number of standard deviations above the mean of the superbias error 
+        Number of standard deviations above the mean of the superbias error
         image at which a pixel is flagged as UNRELIABLE_BIAS.
 
     plot : bool
-        Option to save a histogram of the superbias error image values, with 
+        Option to save a histogram of the superbias error image values, with
         the threshold used for flagging UNRELIABLE_BIAS pixels also shown.
 
     Returns
     -------
     dq : numpy.ndarray
-        A 2D DQ image that flags pixels with high superbias error values as 
+        A 2D DQ image that flags pixels with high superbias error values as
         UNRELIABLE_BIAS (2) and DO_NOT_USE (1).
     """
 
@@ -131,7 +132,7 @@ def find_unreliable_bias_pixels(error, bad_clipping_sigma=3.0,
     dq[~np.isfinite(error)] = 3
 
     # Flag pixels X sigma greater than the mean in the error image
-    clipped = sigma_clip(error, sigma=bad_clipping_sigma, 
+    clipped = sigma_clip(error, sigma=bad_clipping_sigma,
                          maxiters=bad_max_clipping_iters)
     mean = np.mean(clipped)
     std = np.std(clipped)
@@ -142,7 +143,7 @@ def find_unreliable_bias_pixels(error, bad_clipping_sigma=3.0,
     if plot:
         error_no_nan = error.flatten()
         error_no_nan = error_no_nan[np.isfinite(error_no_nan)]
-        plt.hist(error_no_nan, range=(0, thresh*3), bins=80, 
+        plt.hist(error_no_nan, range=(0, thresh*3), bins=80,
                  color='steelblue')
         plt.axvline(thresh, ls='--', color='red')
         plt.yscale('log')
@@ -155,13 +156,13 @@ def find_unreliable_bias_pixels(error, bad_clipping_sigma=3.0,
     return dq
 
 def get_crds_info(filename, subarray, readpatt):
-    """Get CRDS-required header information to put into the final superbias 
+    """Get CRDS-required header information to put into the final superbias
     reference file.
 
     Parameters
     ----------
     filename : str
-        Path to one of the files being used to generate the superbias 
+        Path to one of the files being used to generate the superbias
         reference file. Will be used to find default values.
 
     subarray : str
@@ -186,7 +187,7 @@ def get_crds_info(filename, subarray, readpatt):
 
     fastaxis : int
         CRDS-required fastaxis of the reference file.
-    
+
     slowaxis : int
         CRDS-required slowaxis of the reference file.
 
@@ -212,10 +213,10 @@ def get_crds_info(filename, subarray, readpatt):
 
     return instrument, detector, subarray, readpatt, fastaxis, slowaxis, substrt1, substrt2
 
-def make_filled_superbias(superbias, refpix_map, bad_clipping_sigma=3.0, 
-                          bad_max_clipping_iters=3, bad_sigma_threshold=5.0, 
+def make_filled_superbias(superbias, refpix_map, bad_clipping_sigma=3.0,
+                          bad_max_clipping_iters=3, bad_sigma_threshold=5.0,
                           box_width=3, outfile='superbias_jwst_reffiles.fits'):
-    """Create a version of the superbias image where the values of high 
+    """Create a version of the superbias image where the values of high
     superbias pixels are replaced by their smoothed values.
 
     Parameters
@@ -224,19 +225,19 @@ def make_filled_superbias(superbias, refpix_map, bad_clipping_sigma=3.0,
         A 2D superbias image.
 
     refpix_map : numpy.ndarray
-        A 2D image where refpix have a value of 1 and all other pixels have 
+        A 2D image where refpix have a value of 1 and all other pixels have
         a value of 0.
 
     bad_clipping_sigma : float
-        Number of sigma to use when sigma-clipping to find UNRELIABLE_BIAS 
+        Number of sigma to use when sigma-clipping to find UNRELIABLE_BIAS
         pixels.
 
     bad_max_clipping_iters : int
-        Maximum number of iterations to use when sigma-clipping to find 
+        Maximum number of iterations to use when sigma-clipping to find
         UNRELIABLE_BIAS pixels.
 
     bad_sigma_threshold : float
-        Number of standard deviations above the mean at which a pixel is 
+        Number of standard deviations above the mean at which a pixel is
         flagged as UNRELIABLE_BIAS.
 
     box_width : int
@@ -245,7 +246,7 @@ def make_filled_superbias(superbias, refpix_map, bad_clipping_sigma=3.0,
 
     outfile : str
         Name of the CRDS-formatted superbias reference file to save the final
-        superbias map to. This is only used in this function to name the  
+        superbias map to. This is only used in this function to name the
         filled output file.
     """
 
@@ -257,13 +258,13 @@ def make_filled_superbias(superbias, refpix_map, bad_clipping_sigma=3.0,
     xmax = np.max(scipix[1]) + 1
     superbias_no_refpix = superbias[ymin:ymax, xmin:xmax].copy()
 
-    # Make initial DQ arrays, with and without refpix, to store pixels 
+    # Make initial DQ arrays, with and without refpix, to store pixels
     # with high superbias values.
     dq = np.zeros(superbias.shape, dtype=int)
     dq_no_refpix = np.zeros(superbias_no_refpix.shape, dtype=int)
 
-    # Median-filter the superbias image; replace any nans/infs first as 
-    # these mess up the smoothing. Then subtract this smoothed image from 
+    # Median-filter the superbias image; replace any nans/infs first as
+    # these mess up the smoothing. Then subtract this smoothed image from
     # the original superbias image.
     superbias_no_refpix[~np.isfinite(superbias_no_refpix)] = \
         np.nanmedian(superbias_no_refpix)
@@ -271,7 +272,7 @@ def make_filled_superbias(superbias, refpix_map, bad_clipping_sigma=3.0,
     diff = superbias_no_refpix - smoothed
 
     # Flag pixels X sigma greater than the mean in the difference image
-    clipped = sigma_clip(diff, sigma=bad_clipping_sigma, 
+    clipped = sigma_clip(diff, sigma=bad_clipping_sigma,
                          maxiters=bad_max_clipping_iters)
     mean = np.mean(clipped)
     std = np.std(clipped)
@@ -297,15 +298,15 @@ def make_refpix_map(filename):
     Parameters
     ----------
     filename : str
-        The fits image file to create the refpix map from. The PIXELDQ 
+        The fits image file to create the refpix map from. The PIXELDQ
         extension is used to find the refpix.
 
     Returns
     -------
     refpix_map : numpy.ndarray
-        A map of the reference pixels (same dimensions as the input fits file 
+        A map of the reference pixels (same dimensions as the input fits file
         image extensions), where refpix are 1 and all other pixels are 0.
-        An array of all zeros is returned if no refpix are found or if no 
+        An array of all zeros is returned if no refpix are found or if no
         PIXELDQ extension exists.
     """
 
@@ -326,49 +327,49 @@ def make_refpix_map(filename):
 
     return refpix_map
 
-def make_superbias(filenames, clipping_sigma=3.0, max_clipping_iters=3, 
-                   bad_clipping_sigma=3.0, bad_max_clipping_iters=3, 
-                   bad_sigma_threshold=5.0, plot=False, save_filled=False, 
-                   box_width=3, save_reffile=True, 
-                   outfile='superbias_jwst_reffiles.fits', 
-                   author='jwst_reffiles', description='Super Bias Image', 
-                   pedigree='GROUND', useafter='2000-01-01T00:00:00', 
+def make_superbias(filenames, clipping_sigma=3.0, max_clipping_iters=3,
+                   bad_clipping_sigma=3.0, bad_max_clipping_iters=3,
+                   bad_sigma_threshold=5.0, plot=False, save_filled=False,
+                   box_width=3, save_reffile=True,
+                   outfile='superbias_jwst_reffiles.fits',
+                   author='jwst_reffiles', description='Super Bias Image',
+                   pedigree='GROUND', useafter='2000-01-01T00:00:00',
                    history='', subarray=None, readpatt=None):
-    """The main function. Creates a superbias reference file using the input 
+    """The main function. Creates a superbias reference file using the input
     dark current ramps. See module docstring for more details.
-    
+
     Parameters
     ----------
     filenames : list
-        List of dark current ramp files. The data shape in these images is 
+        List of dark current ramp files. The data shape in these images is
         assumed to be a 4D array in DMS format (integration, group, y, x).
 
     clipping_sigma : float
-        Number of sigma to use when sigma-clipping through the 0th frame  
+        Number of sigma to use when sigma-clipping through the 0th frame
         stack to create the superbias image.
 
     max_clipping_iters : int
-        Maximum number of iterations to use when sigma-clipping through   
+        Maximum number of iterations to use when sigma-clipping through
         the 0th frame stack to create the superbias error image.
 
     bad_clipping_sigma : float
-        Number of sigma to use when sigma-clipping the superbias error image 
+        Number of sigma to use when sigma-clipping the superbias error image
         to find UNRELIABLE_BIAS pixels.
 
     bad_max_clipping_iters : int
-        Maximum number of iterations to use when sigma-clipping the superbias 
+        Maximum number of iterations to use when sigma-clipping the superbias
         error image to find UNRELIABLE_BIAS pixels.
 
     bad_sigma_threshold : float
-        Number of standard deviations above the mean of the superbias error 
+        Number of standard deviations above the mean of the superbias error
         image at which a pixel is flagged as UNRELIABLE_BIAS.
 
     plot : bool
-        Option to save a histogram of the superbias error image values, with 
+        Option to save a histogram of the superbias error image values, with
         the threshold used for flagging UNRELIABLE_BIAS pixels also shown.
 
     save_filled : bool
-        Option to save an image where high superbias pixels are replaced by 
+        Option to save an image where high superbias pixels are replaced by
         their smoothed values.
 
     box_width : int
@@ -376,7 +377,7 @@ def make_superbias(filenames, clipping_sigma=3.0, max_clipping_iters=3,
         superbias image. Only relevant if save_filled=True.
 
     save_reffile : bool
-        Option to save the generated superbias map into a CRDS-formatted 
+        Option to save the generated superbias map into a CRDS-formatted
         reference file.
 
     outfile : str
@@ -415,10 +416,10 @@ def make_superbias(filenames, clipping_sigma=3.0, max_clipping_iters=3,
         stack[i] = fits.getdata(filename, 'SCI')[0, 0, :, :].astype(float)
 
     # Calculate the superbias as the sigma-clipped mean through the stack
-    superbias = calculate_mean(stack, clipping_sigma=clipping_sigma, 
+    superbias = calculate_mean(stack, clipping_sigma=clipping_sigma,
                                max_clipping_iters=max_clipping_iters)
 
-    # Convert masked array to normal numpy array and check for any missing 
+    # Convert masked array to normal numpy array and check for any missing
     # data.
     superbias = superbias.filled(fill_value=np.nan)
     n_bad = len(superbias[~np.isfinite(superbias)])
@@ -441,7 +442,7 @@ def make_superbias(filenames, clipping_sigma=3.0, max_clipping_iters=3,
             get_crds_info(filenames[0], subarray, readpatt)
 
         # Calculate the superbias error as the sigma-clipped stddev through the stack
-        error = calculate_stddev(stack, clipping_sigma=clipping_sigma, 
+        error = calculate_stddev(stack, clipping_sigma=clipping_sigma,
                                  max_clipping_iters=max_clipping_iters)
 
         # Convert masked array to normal numpy array and check for any missing data
@@ -452,28 +453,28 @@ def make_superbias(filenames, clipping_sigma=3.0, max_clipping_iters=3,
                   .format(n_bad))
 
         # Flag pixels with high superbias error values as UNRELIABLE_BIAS
-        dq = find_unreliable_bias_pixels(error, 
+        dq = find_unreliable_bias_pixels(error,
                                          bad_clipping_sigma=bad_clipping_sigma,
                                          bad_max_clipping_iters=bad_max_clipping_iters,
                                          bad_sigma_threshold=bad_sigma_threshold,
                                          plot=plot)
 
-        # Save a version of the superbias where high superbias values are 
+        # Save a version of the superbias where high superbias values are
         # replaced by their smoothed values.
         if save_filled:
             refpix_map = make_refpix_map(filenames[0])
-            make_filled_superbias(superbias, refpix_map, 
-                                  bad_clipping_sigma=bad_clipping_sigma, 
-                                  bad_max_clipping_iters=bad_max_clipping_iters, 
-                                  bad_sigma_threshold=bad_sigma_threshold, 
+            make_filled_superbias(superbias, refpix_map,
+                                  bad_clipping_sigma=bad_clipping_sigma,
+                                  bad_max_clipping_iters=bad_max_clipping_iters,
+                                  bad_sigma_threshold=bad_sigma_threshold,
                                   box_width=box_width, outfile=outfile)
 
         # Save CRDS-formatted superbias reference file
-        save_superbias(superbias, error, dq, instrument=instrument, 
-                       detector=detector, subarray=subarray, readpatt=readpatt, 
-                       outfile=outfile, author=author, description=description, 
-                       pedigree=pedigree, useafter=useafter, history=history, 
-                       fastaxis=fastaxis, slowaxis=slowaxis, substrt1=substrt1, 
+        save_superbias(superbias, error, dq, instrument=instrument,
+                       detector=detector, subarray=subarray, readpatt=readpatt,
+                       outfile=outfile, author=author, description=description,
+                       pedigree=pedigree, useafter=useafter, history=history,
+                       fastaxis=fastaxis, slowaxis=slowaxis, substrt1=substrt1,
                        substrt2=substrt2, filenames=filenames)
 
     return superbias
@@ -485,7 +486,7 @@ def none_check(value):
     Parameters
     ----------
     value : str or NoneType
-    
+
     Returns
     -------
     new_value : NoneType
@@ -501,12 +502,12 @@ def none_check(value):
 
     return new_value
 
-def save_superbias(superbias, error, dq, instrument='', detector='', 
-                   subarray='GENERIC', readpatt='ANY', 
-                   outfile='superbias_jwst_reffiles.fits', 
-                   author='jwst_reffiles', description='Super Bias Image', 
-                   pedigree='GROUND', useafter='2000-01-01T00:00:00', 
-                   history='', fastaxis=-1, slowaxis=2, substrt1=1, substrt2=1, 
+def save_superbias(superbias, error, dq, instrument='', detector='',
+                   subarray='GENERIC', readpatt='ANY',
+                   outfile='superbias_jwst_reffiles.fits',
+                   author='jwst_reffiles', description='Super Bias Image',
+                   pedigree='GROUND', useafter='2000-01-01T00:00:00',
+                   history='', fastaxis=-1, slowaxis=2, substrt1=1, substrt2=1,
                    filenames=[]):
     """Saves a CRDS-formatted superbias reference file.
 
@@ -557,7 +558,7 @@ def save_superbias(superbias, error, dq, instrument='', detector='',
 
     fastaxis : int
         CRDS-required fastaxis of the reference file.
-    
+
     slowaxis : int
         CRDS-required slowaxis of the reference file.
 
@@ -568,12 +569,12 @@ def save_superbias(superbias, error, dq, instrument='', detector='',
         CRDS-required starting pixel in axis 2 direction.
 
     filenames : list
-        List of dark current files that were used to generate the reference 
+        List of dark current files that were used to generate the reference
         file.
     """
 
     s = SuperBiasModel()
-    
+
     s.data = superbias
     s.err = error
     s.dq = dq
@@ -618,9 +619,9 @@ def save_superbias(superbias, error, dq, instrument='', detector='',
                 s.history.append(util.create_history_entry(f[val:val+60]))
             else:
                 s.history.append(util.create_history_entry(f[val:]))
-    
+
     if history != '':
         s.history.append(util.create_history_entry(history))
-    
+
     s.save(outfile, overwrite=True)
     print('Final CRDS-formatted superbias map saved to {}'.format(outfile))


### PR DESCRIPTION
This PR updates several of the reference file creation scripts that use create_history_entry. This function used to be in jwst.datamodels.util. In a recent update though, the function is now in stdatamodels.util.

stdatamodels is a dependency of the jwst package, so anyone who has jwst installed should already have stdatamodels. So this PR simply updates the relevant import statements to point to the new location.