### PR TITLE
Bugfixes for bad pixel mask

### DIFF
--- a/jwst_reffiles/bad_pixel_mask/badpix_from_flats.py
+++ b/jwst_reffiles/bad_pixel_mask/badpix_from_flats.py
@@ -187,6 +187,11 @@ def find_bad_pix(input_files, dead_search=True, low_qe_and_open_search=True, dea
     quality_check : bool
         If True, the pipeline is run using the output reference file to be
         sure the pipeline doens't crash
+
+    Returns
+    -------
+    final_map : numpy.ndarray
+        2D array containing the combined bad pixel map
     """
     # Inputs listed as None in the config file are read in as strings.
     # Change these to NoneType objects.

--- a/jwst_reffiles/utils/constants.py
+++ b/jwst_reffiles/utils/constants.py
@@ -4,4 +4,4 @@
 jwst_reffiles modules
 """
 
-RATE_FILE_SUFFIXES = ['_0_ramp_fit', '_1_ramp_fit', '_ramp_fit_0', '_ramp_fit_1']
+RATE_FILE_SUFFIXES = ['_rate', '_0_ramp_fit', '_1_ramp_fit', '_ramp_fit_0', '_ramp_fit_1']


### PR DESCRIPTION
This PR contains a few small bug fixes for the bad pixel generator, based on experience running the code for the JWQL project. First, this adds 'rate' to the list of allowed suffixes for pipeline-output rate files. Previously the allowed suffixes were only those that come from running the ramp_fit step individually (e.g. ramp_fit_0).

The corrected bugs involve running the bad_pixel_mask.py script for a case where only flats or only darks are provided as input. In this case, there will not be two bad pixel masks to be combined. Previously the code was assuming that both masks were present.
