### PR TITLE
Tweaks to allow rateints files to be used

### DIFF
--- a/jwst_reffiles/dark_current/badpix_from_darks.py
+++ b/jwst_reffiles/dark_current/badpix_from_darks.py
@@ -986,7 +986,7 @@ def read_slope_files(filenames):
     print('METADATA check turned off for testing with old NIRCAM data that is missing keywords')
     for i, filename in enumerate(filenames):
         # Read all of the slope data into an array
-        slope_file = filename.replace('jump.fits', 'rateint.fits')
+        slope_file = filename.replace('jump.fits', 'rateints.fits')
         with fits.open(slope_file) as hdulist:
             slope_img = hdulist['SCI'].data
             dq_img = hdulist['DQ'].data

--- a/jwst_reffiles/utils/constants.py
+++ b/jwst_reffiles/utils/constants.py
@@ -4,4 +4,4 @@
 jwst_reffiles modules
 """
 
-RATE_FILE_SUFFIXES = ['_rate', '_0_ramp_fit', '_1_ramp_fit', '_ramp_fit_0', '_ramp_fit_1']
+RATE_FILE_SUFFIXES = ['_rateints', '_rate', '_0_ramp_fit', '_1_ramp_fit', '_ramp_fit_0', '_ramp_fit_1']


### PR DESCRIPTION
We need to have a 1-to-1 corespondance between rate files, jump files, and fitopt files. If the inputs are exposures with multiple integrations, then rateints files are the only way to get this correspondance. Just a couple of tweaks here to be sure we can run with rateints files.