### PR TITLE
Fix commented header in fgs manual pix files

### DIFF
--- a/jwst_reffiles/bad_pixel_mask/badpix_from_flats.py
+++ b/jwst_reffiles/bad_pixel_mask/badpix_from_flats.py
@@ -913,7 +913,8 @@ def manual_flags(filename, map_shape, no_use):
     Parameters
     ----------
     filename : str
-        Name of ascii file containing flags
+        Name of ascii file containing flags. File must contain columns
+        'x', 'y', 'flags'
 
     map_shape : tup
         Shape of the bad pixel mask to create (y, x)

--- a/jwst_reffiles/bad_pixel_mask/fgs_guider1_manual_flags.txt
+++ b/jwst_reffiles/bad_pixel_mask/fgs_guider1_manual_flags.txt
@@ -12,7 +12,7 @@
 #
 # This is a list of bad pixels for the NIRCam A1 detector
 #
-# x       y       flag
+  x       y       flag
 1023    1023      dead
 0:2047    0       dead
 0      0:2047     low_qe

--- a/jwst_reffiles/bad_pixel_mask/fgs_guider2_manual_flags.txt
+++ b/jwst_reffiles/bad_pixel_mask/fgs_guider2_manual_flags.txt
@@ -12,7 +12,7 @@
 #
 # This is a list of bad pixels for the NIRCam A1 detector
 #
-# x       y       flag
+  x       y       flag
 1023    1023      dead
 0:2047    0       dead
 0      0:2047     low_qe


### PR DESCRIPTION
The row containing the column names was commented out, and so ascii.read() was skipping over it and using generic values for the row names. This was causing jwql to fail, when row['x'] was referenced.